### PR TITLE
Change primary CLI command from 'threat-radar' to 'tr' (Issue #123)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
           
           ### Verify
           ```bash
-          threat-radar --version
-          threat-radar --help
+          tr --version
+          tr --help
           ```
         draft: false
         prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
           
           ### Verify
           ```bash
-          tr --version
-          tr --help
+          tradar --version
+          tradar --help
           ```
         draft: false
         prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,5 +34,5 @@ jobs:
     
     - name: Test CLI
       run: |
-        tr --help
+        tradar --help
         threat-radar --help  # Test backward compatibility

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,5 @@ jobs:
     
     - name: Test CLI
       run: |
-        threat-radar --help
+        tr --help
+        threat-radar --help  # Test backward compatibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,44 +13,44 @@ Common development tasks:
 ```bash
 # Setup and verify installation
 pip install -e .
-tr --help
+tradar --help
 
 # Run vulnerability scan
-tr cve scan-image alpine:3.18 --auto-save
+tradar cve scan-image alpine:3.18 --auto-save
 
 # Use global options for verbose output and JSON format
-tr -vv -f json cve scan-image python:3.11 --auto-save
+tradar -vv -f json cve scan-image python:3.11 --auto-save
 
 # Load configuration from custom file
-tr --config ./myconfig.json cve scan-image ubuntu:22.04
+tradar --config ./myconfig.json cve scan-image ubuntu:22.04
 
 # Quiet mode for CI/CD (errors only)
-tr -q --no-color cve scan-image myapp:latest --fail-on HIGH
+tradar -q --no-color cve scan-image myapp:latest --fail-on HIGH
 
 # Generate SBOM
-tr sbom docker python:3.11 -o sbom.json
+tradar sbom docker python:3.11 -o sbom.json
 
 # Run AI analysis (requires API key in .env)
-tr ai analyze scan-results.json --auto-save
+tradar ai analyze scan-results.json --auto-save
 
 # Generate comprehensive report
-tr report generate scan-results.json -o report.html -f html
+tradar report generate scan-results.json -o report.html -f html
 
 # Build vulnerability graph for relationship analysis
-tr graph build scan-results.json --auto-save
-tr graph query graph.graphml --cve CVE-2023-1234
-tr graph query graph.graphml --top-packages 10 --stats
+tradar graph build scan-results.json --auto-save
+tradar graph query graph.graphml --cve CVE-2023-1234
+tradar graph query graph.graphml --top-packages 10 --stats
 
 # Attack path discovery and security analysis
-tr graph attack-paths graph.graphml --max-paths 20 -o paths.json
-tr graph privilege-escalation graph.graphml -o privesc.json
-tr graph lateral-movement graph.graphml -o lateral.json
-tr graph attack-surface graph.graphml -o attack-surface.json
+tradar graph attack-paths graph.graphml --max-paths 20 -o paths.json
+tradar graph privilege-escalation graph.graphml -o privesc.json
+tradar graph lateral-movement graph.graphml -o lateral.json
+tradar graph attack-surface graph.graphml -o attack-surface.json
 
 # Environment configuration and business context
-tr env validate my-environment.json
-tr env build-graph production.json --auto-save
-tr env analyze-risk production.json scan-results.json --auto-save
+tradar env validate my-environment.json
+tradar env build-graph production.json --auto-save
+tradar env analyze-risk production.json scan-results.json --auto-save
 
 # Run tests
 pytest                                    # All tests
@@ -85,10 +85,10 @@ The package provides two CLI entry points:
 
 ```bash
 # Available commands
-tr --help
-tr cve --help
-tr docker --help
-tr sbom --help
+tradar --help
+tradar cve --help
+tradar docker --help
+tradar sbom --help
 ```
 
 ### Testing
@@ -157,13 +157,13 @@ Control the amount of output and logging:
 **Examples:**
 ```bash
 # Quiet mode for automation
-tr -q cve scan-image alpine:3.18
+tradar -q cve scan-image alpine:3.18
 
 # Verbose debugging
-tr -vv cve scan-image python:3.11
+tradar -vv cve scan-image python:3.11
 
 # Very verbose with all internal logging
-tr -vvv ai analyze scan.json
+tradar -vvv ai analyze scan.json
 ```
 
 ### Configuration File Support
@@ -225,26 +225,26 @@ Threat Radar supports persistent configuration through JSON files. Configuration
 
 ```bash
 # Initialize new configuration file
-tr config init
-tr config init --path ./my-config.json
-tr config init --force  # Overwrite existing
+tradar config init
+tradar config init --path ./my-config.json
+tradar config init --force  # Overwrite existing
 
 # Show current configuration
-tr config show
-tr config show scan.severity
-tr config show ai.provider
+tradar config show
+tradar config show scan.severity
+tradar config show ai.provider
 
 # Modify configuration
-tr config set scan.severity HIGH
-tr config set ai.provider ollama
-tr config set output.verbosity 2
+tradar config set scan.severity HIGH
+tradar config set ai.provider ollama
+tradar config set output.verbosity 2
 
 # Validate configuration file
-tr config validate
-tr config validate ./my-config.json
+tradar config validate
+tradar config validate ./my-config.json
 
 # Show configuration file locations
-tr config path
+tradar config path
 ```
 
 ### Output Formats
@@ -259,13 +259,13 @@ Threat Radar supports multiple output formats for different use cases:
 **Examples:**
 ```bash
 # JSON output for automation
-tr -f json cve scan-image alpine:3.18
+tradar -f json cve scan-image alpine:3.18
 
 # CSV output for spreadsheets
-tr -f csv sbom components sbom.json -o packages.csv
+tradar -f csv sbom components sbom.json -o packages.csv
 
 # Combine with other global options
-tr -q -f json --no-color cve scan-image myapp:latest > results.json
+tradar -q -f json --no-color cve scan-image myapp:latest > results.json
 ```
 
 **For complete CLI features documentation, see [docs/CLI_FEATURES.md](docs/CLI_FEATURES.md)**
@@ -374,37 +374,37 @@ grype version
 
 ```bash
 # Scan Docker image for CVEs
-tr cve scan-image alpine:3.18
-tr cve scan-image python:3.11 --severity HIGH
-tr cve scan-image ubuntu:22.04 --only-fixed -o results.json
+tradar cve scan-image alpine:3.18
+tradar cve scan-image python:3.11 --severity HIGH
+tradar cve scan-image ubuntu:22.04 --only-fixed -o results.json
 
 # Scan with automatic cleanup (removes image after scan if newly pulled)
-tr cve scan-image nginx:latest --cleanup
-tr cve scan-image test-app:v1.0 --cleanup --severity HIGH
+tradar cve scan-image nginx:latest --cleanup
+tradar cve scan-image test-app:v1.0 --cleanup --severity HIGH
 
 # Auto-save results to storage/cve_storage/ directory
-tr cve scan-image alpine:3.18 --auto-save
-tr cve scan-image myapp:latest --as  # Short form
-tr cve scan-image python:3.11 --auto-save --cleanup  # Combined
+tradar cve scan-image alpine:3.18 --auto-save
+tradar cve scan-image myapp:latest --as  # Short form
+tradar cve scan-image python:3.11 --auto-save --cleanup  # Combined
 
 # Scan pre-generated SBOM file (CI/CD friendly)
-tr cve scan-sbom my-app-sbom.json
-tr cve scan-sbom docker-sbom.json --severity CRITICAL
-tr cve scan-sbom sbom.json --only-fixed -o cve-results.json
+tradar cve scan-sbom my-app-sbom.json
+tradar cve scan-sbom docker-sbom.json --severity CRITICAL
+tradar cve scan-sbom sbom.json --only-fixed -o cve-results.json
 
 # SBOM scanning with cleanup and auto-save
-tr cve scan-sbom alpine-sbom.json --cleanup --image alpine:3.18
-tr cve scan-sbom app-sbom.json --auto-save  # Auto-save results
+tradar cve scan-sbom alpine-sbom.json --cleanup --image alpine:3.18
+tradar cve scan-sbom app-sbom.json --auto-save  # Auto-save results
 
 # Scan local directory for vulnerabilities
-tr cve scan-directory ./my-app
-tr cve scan-directory /path/to/project --severity MEDIUM
-tr cve scan-directory . --only-fixed -o results.json
-tr cve scan-directory ./src --auto-save  # Auto-save
+tradar cve scan-directory ./my-app
+tradar cve scan-directory /path/to/project --severity MEDIUM
+tradar cve scan-directory . --only-fixed -o results.json
+tradar cve scan-directory ./src --auto-save  # Auto-save
 
 # Vulnerability database management
-tr cve db-update                     # Update Grype database
-tr cve db-status                     # Show database status
+tradar cve db-update                     # Update Grype database
+tradar cve db-status                     # Show database status
 ```
 
 ### CVE Scanning Workflow
@@ -441,14 +441,14 @@ The `--cleanup` flag automatically removes Docker images after scanning to save 
 **Use cases:**
 ```bash
 # CI/CD pipelines - scan and cleanup
-tr cve scan-image myapp:latest --cleanup --severity HIGH
+tradar cve scan-image myapp:latest --cleanup --severity HIGH
 
 # Testing multiple images without storage buildup
-tr cve scan-image nginx:alpine --cleanup
-tr cve scan-image redis:alpine --cleanup
+tradar cve scan-image nginx:alpine --cleanup
+tradar cve scan-image redis:alpine --cleanup
 
 # SBOM scanning with source image cleanup
-tr cve scan-sbom app-sbom.json --cleanup --image myapp:v1.0
+tradar cve scan-sbom app-sbom.json --cleanup --image myapp:v1.0
 ```
 
 **Storage management:**
@@ -470,15 +470,15 @@ The `--auto-save` (or `--as`) flag automatically saves CVE scan results to the `
 **Use cases:**
 ```bash
 # Keep history of all scans in one place
-tr cve scan-image myapp:v1.0 --auto-save
-tr cve scan-image myapp:v1.1 --auto-save
-tr cve scan-image myapp:v1.2 --auto-save
+tradar cve scan-image myapp:v1.0 --auto-save
+tradar cve scan-image myapp:v1.1 --auto-save
+tradar cve scan-image myapp:v1.2 --auto-save
 
 # CI/CD: Auto-save + cleanup for ephemeral environments
-tr cve scan-image $IMAGE --auto-save --cleanup --fail-on HIGH
+tradar cve scan-image $IMAGE --auto-save --cleanup --fail-on HIGH
 
 # Save to both custom location and auto-save
-tr cve scan-image alpine:3.18 -o report.json --auto-save
+tradar cve scan-image alpine:3.18 -o report.json --auto-save
 ```
 
 **File naming examples:**
@@ -505,13 +505,13 @@ find storage/cve_storage/ -name "*.json" -mtime +30 -delete  # Remove >30 days o
 
 ```bash
 # Generate SBOM with Syft
-tr sbom generate docker:alpine:3.18 -o sbom.json
+tradar sbom generate docker:alpine:3.18 -o sbom.json
 
 # Scan SBOM with Grype for vulnerabilities
-tr cve scan-sbom sbom.json --severity HIGH -o vulns.json
+tradar cve scan-sbom sbom.json --severity HIGH -o vulns.json
 
 # Or scan Docker image directly (Grype handles SBOM internally)
-tr cve scan-image alpine:3.18 --severity HIGH -o vulns.json
+tradar cve scan-image alpine:3.18 --severity HIGH -o vulns.json
 ```
 
 ## AI Commands Reference
@@ -554,20 +554,20 @@ Analyze CVE scan results to understand exploitability and business impact:
 
 ```bash
 # Basic analysis (auto-batches for large scans)
-tr ai analyze cve-results.json
+tradar ai analyze cve-results.json
 
 # Specify AI provider and model
-tr ai analyze results.json --provider openai --model gpt-4o
-tr ai analyze results.json --provider anthropic --model claude-3-5-sonnet-20241022
+tradar ai analyze results.json --provider openai --model gpt-4o
+tradar ai analyze results.json --provider anthropic --model claude-3-5-sonnet-20241022
 
 # Save analysis to file
-tr ai analyze scan.json -o analysis.json
+tradar ai analyze scan.json -o analysis.json
 
 # Auto-save to storage/ai_analysis/
-tr ai analyze results.json --auto-save
+tradar ai analyze results.json --auto-save
 
 # Use local model (Ollama)
-tr ai analyze scan.json --provider ollama --model llama2
+tradar ai analyze scan.json --provider ollama --model llama2
 ```
 
 **BATCH PROCESSING FOR LARGE SCANS:**
@@ -576,16 +576,16 @@ Automatically handles 100+ CVE scans via intelligent batch processing:
 
 ```bash
 # Auto-batch mode (default) - automatically batches when >30 CVEs
-tr ai analyze large-scan.json
+tradar ai analyze large-scan.json
 
 # Force batch processing with custom size
-tr ai analyze scan.json --batch-mode enabled --batch-size 30
+tradar ai analyze scan.json --batch-mode enabled --batch-size 30
 
 # Disable batching (use single-pass, may fail for large scans)
-tr ai analyze scan.json --batch-mode disabled
+tradar ai analyze scan.json --batch-mode disabled
 
 # Hide progress bar (useful for CI/CD)
-tr ai analyze scan.json --no-progress
+tradar ai analyze scan.json --no-progress
 ```
 
 **How batch processing works:**
@@ -607,16 +607,16 @@ Reduce analysis time and cost by filtering to specific severity levels:
 
 ```bash
 # Analyze only CRITICAL vulnerabilities
-tr ai analyze scan.json --severity critical
+tradar ai analyze scan.json --severity critical
 
 # Analyze HIGH and above (critical + high)
-tr ai analyze scan.json --severity high
+tradar ai analyze scan.json --severity high
 
 # Analyze MEDIUM and above (critical + high + medium)
-tr ai analyze scan.json --severity medium
+tradar ai analyze scan.json --severity medium
 
 # Combine with batch processing
-tr ai analyze large-scan.json --severity high --batch-size 20
+tradar ai analyze large-scan.json --severity high --batch-size 20
 ```
 
 **Severity levels** (from highest to lowest):
@@ -644,16 +644,16 @@ Generate AI-powered prioritized vulnerability lists:
 
 ```bash
 # Generate priority list
-tr ai prioritize cve-results.json
+tradar ai prioritize cve-results.json
 
 # Show top 20 priorities
-tr ai prioritize results.json --top 20
+tradar ai prioritize results.json --top 20
 
 # Save prioritization
-tr ai prioritize scan.json -o priorities.json
+tradar ai prioritize scan.json -o priorities.json
 
 # Auto-save results
-tr ai prioritize results.json --auto-save
+tradar ai prioritize results.json --auto-save
 ```
 
 **Output includes:**
@@ -669,16 +669,16 @@ Create detailed, actionable remediation guidance:
 
 ```bash
 # Generate remediation plan
-tr ai remediate cve-results.json
+tradar ai remediate cve-results.json
 
 # Save plan to file
-tr ai remediate scan.json -o remediation.json
+tradar ai remediate scan.json -o remediation.json
 
 # Hide upgrade commands
-tr ai remediate results.json --no-commands
+tradar ai remediate results.json --no-commands
 
 # Use local model
-tr ai remediate scan.json --provider ollama
+tradar ai remediate scan.json --provider ollama
 ```
 
 **Output includes:**
@@ -697,25 +697,25 @@ tr ai remediate scan.json --provider ollama
 
 ```bash
 # 1. Scan Docker image for vulnerabilities
-tr cve scan-image alpine:3.18 --auto-save -o cve-scan.json
+tradar cve scan-image alpine:3.18 --auto-save -o cve-scan.json
 
 # 2. Analyze with AI
-tr ai analyze cve-scan.json --auto-save -o ai-analysis.json
+tradar ai analyze cve-scan.json --auto-save -o ai-analysis.json
 
 # 3. Generate priorities
-tr ai prioritize cve-scan.json --auto-save -o priorities.json
+tradar ai prioritize cve-scan.json --auto-save -o priorities.json
 
 # 4. Create remediation plan
-tr ai remediate cve-scan.json --auto-save -o remediation.json
+tradar ai remediate cve-scan.json --auto-save -o remediation.json
 ```
 
 #### CI/CD Integration
 
 ```bash
 # Scan, analyze, and prioritize in one pipeline
-tr cve scan-image $IMAGE --auto-save --cleanup > scan.json
-tr ai analyze scan.json --auto-save
-tr ai prioritize scan.json --top 10 --auto-save
+tradar cve scan-image $IMAGE --auto-save --cleanup > scan.json
+tradar ai analyze scan.json --auto-save
+tradar ai prioritize scan.json --top 10 --auto-save
 ```
 
 #### Using Local Models (Privacy-Focused)
@@ -729,9 +729,9 @@ tr ai prioritize scan.json --top 10 --auto-save
 export AI_PROVIDER=ollama
 export AI_MODEL=llama2
 
-tr ai analyze cve-scan.json
-tr ai prioritize cve-scan.json
-tr ai remediate cve-scan.json
+tradar ai analyze cve-scan.json
+tradar ai prioritize cve-scan.json
+tradar ai remediate cve-scan.json
 ```
 
 ### AI Storage Management
@@ -826,9 +826,9 @@ export AI_PROVIDER=anthropic
 export AI_MODEL=claude-3-5-sonnet-20241022
 
 # Use with any AI command
-tr ai analyze scan.json --provider anthropic
-tr ai prioritize scan.json --provider anthropic
-tr ai remediate scan.json --provider anthropic
+tradar ai analyze scan.json --provider anthropic
+tradar ai prioritize scan.json --provider anthropic
+tradar ai remediate scan.json --provider anthropic
 ```
 
 **Available Claude Models:**
@@ -850,9 +850,9 @@ export AI_PROVIDER=openrouter
 export AI_MODEL=anthropic/claude-3.5-sonnet
 
 # Use with any AI command
-tr ai analyze scan.json --provider openrouter
-tr ai prioritize scan.json --provider openrouter --model openai/gpt-4o
-tr ai remediate scan.json --provider openrouter --model google/gemini-pro
+tradar ai analyze scan.json --provider openrouter
+tradar ai prioritize scan.json --provider openrouter --model openai/gpt-4o
+tradar ai remediate scan.json --provider openrouter --model google/gemini-pro
 ```
 
 **Popular OpenRouter Models:**
@@ -874,19 +874,19 @@ tr ai remediate scan.json --provider openrouter --model google/gemini-pro
 **Example Multi-Model Workflow:**
 ```bash
 # Use Claude for detailed analysis (best reasoning)
-tr ai analyze scan.json \
+tradar ai analyze scan.json \
   --provider openrouter \
   --model anthropic/claude-3.5-sonnet \
   --auto-save
 
 # Use GPT-4o for prioritization (fast structured output)
-tr ai prioritize scan.json \
+tradar ai prioritize scan.json \
   --provider openrouter \
   --model openai/gpt-4o \
   --auto-save
 
 # Use Gemini for cost-effective remediation
-tr ai remediate scan.json \
+tradar ai remediate scan.json \
   --provider openrouter \
   --model google/gemini-pro \
   --auto-save
@@ -916,62 +916,62 @@ export AI_MODEL=llama2
 ### Generation
 ```bash
 # Generate SBOM from local directory
-tr sbom generate ./path/to/project -f cyclonedx-json
+tradar sbom generate ./path/to/project -f cyclonedx-json
 
 # Generate SBOM from Docker image
-tr sbom docker alpine:3.18 -o sbom.json
+tradar sbom docker alpine:3.18 -o sbom.json
 
 # Auto-save to sbom_storage/
-tr sbom generate . --auto-save
-tr sbom docker python:3.11 --auto-save
+tradar sbom generate . --auto-save
+tradar sbom docker python:3.11 --auto-save
 ```
 
 ### Analysis
 ```bash
 # Read and display SBOM
-tr sbom read sbom.json
-tr sbom read sbom.json --format json
+tradar sbom read sbom.json
+tradar sbom read sbom.json --format json
 
 # Get statistics
-tr sbom stats sbom.json
+tradar sbom stats sbom.json
 
 # Search for packages
-tr sbom search sbom.json openssl
+tradar sbom search sbom.json openssl
 
 # List components with filtering
-tr sbom components sbom.json --type library
-tr sbom components sbom.json --language python
-tr sbom components sbom.json --group-by type
+tradar sbom components sbom.json --type library
+tradar sbom components sbom.json --language python
+tradar sbom components sbom.json --group-by type
 ```
 
 ### Comparison
 ```bash
 # Compare two SBOMs (useful for tracking changes)
-tr sbom compare alpine-3.17-sbom.json alpine-3.18-sbom.json
-tr sbom compare old.json new.json --versions
+tradar sbom compare alpine-3.17-sbom.json alpine-3.18-sbom.json
+tradar sbom compare old.json new.json --versions
 ```
 
 ### Export
 ```bash
 # Export to CSV
-tr sbom export sbom.json -o packages.csv -f csv
+tradar sbom export sbom.json -o packages.csv -f csv
 
 # Export as requirements.txt (Python packages)
-tr sbom export sbom.json -o requirements.txt -f requirements
+tradar sbom export sbom.json -o requirements.txt -f requirements
 ```
 
 ### Storage Management
 ```bash
 # List all stored SBOMs
-tr sbom list
+tradar sbom list
 
 # List by category
-tr sbom list --category docker
-tr sbom list --category local
-tr sbom list --category comparisons
+tradar sbom list --category docker
+tradar sbom list --category local
+tradar sbom list --category comparisons
 
 # Limit results
-tr sbom list --limit 10
+tradar sbom list --limit 10
 ```
 
 ## Comprehensive Reporting Commands
@@ -1001,16 +1001,16 @@ The reporting system provides AI-powered vulnerability reports with multiple out
 IMAGE="myapp:latest"
 
 # 1. Scan image
-tr cve scan-image $IMAGE --auto-save -o scan.json
+tradar cve scan-image $IMAGE --auto-save -o scan.json
 
 # 2. Build graph and find attack paths
-tr graph build scan.json -o graph.graphml
-tr graph attack-paths graph.graphml -o attack-paths.json
+tradar graph build scan.json -o graph.graphml
+tradar graph attack-paths graph.graphml -o attack-paths.json
 
 # 3. Generate reports in all formats with attack paths
-tr report generate scan.json -o report.html --attack-paths attack-paths.json
-tr report generate scan.json -o report.pdf --attack-paths attack-paths.json
-tr report generate scan.json -o report.md --attack-paths attack-paths.json
+tradar report generate scan.json -o report.html --attack-paths attack-paths.json
+tradar report generate scan.json -o report.pdf --attack-paths attack-paths.json
+tradar report generate scan.json -o report.md --attack-paths attack-paths.json
 
 # Result: 3 comprehensive reports (HTML, PDF, Markdown) with:
 # - Vulnerability analysis
@@ -1023,42 +1023,42 @@ tr report generate scan.json -o report.md --attack-paths attack-paths.json
 
 ```bash
 # Generate comprehensive HTML report with AI executive summary
-tr report generate scan-results.json -o report.html -f html
+tradar report generate scan-results.json -o report.html -f html
 
 # Executive summary in Markdown (for documentation)
-tr report generate scan-results.json -o summary.md -f markdown --level executive
+tradar report generate scan-results.json -o summary.md -f markdown --level executive
 
 # Executive PDF report (NEW!)
-tr report generate scan-results.json -o executive.pdf -f pdf --level executive
+tradar report generate scan-results.json -o executive.pdf -f pdf --level executive
 
 # Detailed JSON report with dashboard data
-tr report generate scan-results.json -o detailed.json --level detailed
+tradar report generate scan-results.json -o detailed.json --level detailed
 
 # Critical-only issues (for immediate action)
-tr report generate scan-results.json -o critical.json --level critical-only
+tradar report generate scan-results.json -o critical.json --level critical-only
 
 # Use custom AI model
-tr report generate scan-results.json --ai-provider ollama --ai-model llama2
+tradar report generate scan-results.json --ai-provider ollama --ai-model llama2
 
 # Without AI executive summary (faster)
-tr report generate scan-results.json -o report.json --no-executive
+tradar report generate scan-results.json -o report.json --no-executive
 ```
 
 #### Reports with Attack Path Analysis (NEW!)
 
 ```bash
 # Generate attack paths first
-tr graph build scan.json -o graph.graphml
-tr graph attack-paths graph.graphml -o attack-paths.json
+tradar graph build scan.json -o graph.graphml
+tradar graph attack-paths graph.graphml -o attack-paths.json
 
 # HTML report with integrated attack paths
-tr report generate scan.json \
+tradar report generate scan.json \
   -o comprehensive-report.html \
   -f html \
   --attack-paths attack-paths.json
 
 # PDF executive report with attack path analysis
-tr report generate scan.json \
+tradar report generate scan.json \
   -o executive-with-paths.pdf \
   -f pdf \
   --level executive \
@@ -1066,7 +1066,7 @@ tr report generate scan.json \
   --ai-provider openai
 
 # Markdown documentation with attack paths
-tr report generate scan.json \
+tradar report generate scan.json \
   -o security-analysis.md \
   -f markdown \
   --level detailed \
@@ -1104,7 +1104,7 @@ tr report generate scan.json \
 
 #### JSON Format
 ```bash
-tr report generate scan.json -o report.json -f json
+tradar report generate scan.json -o report.json -f json
 ```
 - Machine-readable structured data
 - Suitable for API integrations
@@ -1113,7 +1113,7 @@ tr report generate scan.json -o report.json -f json
 
 #### Markdown Format
 ```bash
-tr report generate scan.json -o report.md -f markdown
+tradar report generate scan.json -o report.md -f markdown
 ```
 - Human-readable documentation
 - Great for GitHub/GitLab issues
@@ -1122,7 +1122,7 @@ tr report generate scan.json -o report.md -f markdown
 
 #### HTML Format
 ```bash
-tr report generate scan.json -o report.html -f html
+tradar report generate scan.json -o report.html -f html
 ```
 - Beautiful web-based reports
 - Styled with modern CSS
@@ -1136,7 +1136,7 @@ Export visualization-ready data for custom dashboards (Grafana, custom web apps,
 
 ```bash
 # Export dashboard data structure
-tr report dashboard-export scan-results.json -o dashboard.json
+tradar report dashboard-export scan-results.json -o dashboard.json
 ```
 
 **Dashboard data includes:**
@@ -1172,18 +1172,18 @@ Example dashboard.json structure:
 
 ```bash
 # Generate report with integrated attack path analysis
-tr cve scan-image myapp:production --auto-save -o scan.json
-tr graph build scan.json --auto-save -o vuln-graph.graphml
-tr graph attack-paths vuln-graph.graphml --max-paths 20 -o attack-paths.json
+tradar cve scan-image myapp:production --auto-save -o scan.json
+tradar graph build scan.json --auto-save -o vuln-graph.graphml
+tradar graph attack-paths vuln-graph.graphml --max-paths 20 -o attack-paths.json
 
 # Single command to generate comprehensive report with attack paths
-tr report generate scan.json \
+tradar report generate scan.json \
   -o comprehensive-report.html \
   -f html \
   --attack-paths attack-paths.json
 
 # Or with PDF export
-tr report generate scan.json \
+tradar report generate scan.json \
   -o executive-report.pdf \
   -f pdf \
   --level executive \
@@ -1221,32 +1221,32 @@ echo "Generating attack path-aware security report for $TARGET..."
 
 # Step 1: Scan for vulnerabilities
 echo "1. Scanning for vulnerabilities..."
-tr cve scan-image $TARGET --auto-save -o scan.json
+tradar cve scan-image $TARGET --auto-save -o scan.json
 
 # Step 2: Build environment graph with vulnerabilities
 echo "2. Building infrastructure graph..."
-tr env build-graph production-env.json \
+tradar env build-graph production-env.json \
   --merge-scan scan.json \
   --auto-save -o env-graph.graphml
 
 # Step 3: Analyze attack surface
 echo "3. Analyzing attack surface..."
-tr graph attack-surface env-graph.graphml \
+tradar graph attack-surface env-graph.graphml \
   -o attack-surface.json
 
 # Step 4: Find specific attack paths
 echo "4. Discovering attack paths..."
-tr graph attack-paths env-graph.graphml \
+tradar graph attack-paths env-graph.graphml \
   --max-paths 50 -o attack-paths.json
 
 # Step 5: Identify privilege escalation opportunities
 echo "5. Detecting privilege escalation vectors..."
-tr graph privilege-escalation env-graph.graphml \
+tradar graph privilege-escalation env-graph.graphml \
   -o privesc.json
 
 # Step 6: Generate integrated technical report with attack paths (HTML)
 echo "6. Generating technical security report with attack paths..."
-tr report generate scan.json \
+tradar report generate scan.json \
   -o reports/technical-report.html \
   -f html \
   --level detailed \
@@ -1254,7 +1254,7 @@ tr report generate scan.json \
 
 # Step 7: Generate executive PDF report with risk context and attack paths
 echo "7. Generating executive PDF summary..."
-tr report generate scan.json \
+tradar report generate scan.json \
   -o reports/executive-summary.pdf \
   -f pdf \
   --level executive \
@@ -1263,7 +1263,7 @@ tr report generate scan.json \
 
 # Step 8: Generate Markdown report for documentation
 echo "8. Generating Markdown report..."
-tr report generate scan.json \
+tradar report generate scan.json \
   -o reports/security-analysis.md \
   -f markdown \
   --level detailed \
@@ -1271,18 +1271,18 @@ tr report generate scan.json \
 
 # Step 9: Create attack path visualizations
 echo "9. Creating visualizations..."
-tr visualize attack-paths env-graph.graphml \
+tradar visualize attack-paths env-graph.graphml \
   -o reports/attack-paths-viz.html \
   --paths attack-paths.json \
   --max-paths 10
 
-tr visualize topology env-graph.graphml \
+tradar visualize topology env-graph.graphml \
   -o reports/topology-security.html \
   --view zones
 
 # Step 10: Export dashboard data
 echo "10. Exporting dashboard metrics..."
-tr report dashboard-export scan.json \
+tradar report dashboard-export scan.json \
   -o reports/dashboard-data.json
 
 echo "✅ Complete attack-path-aware report generated!"
@@ -1311,25 +1311,25 @@ Threat Radar provides flexible report customization through report levels and AI
 
 ```bash
 # Executive level - For C-suite and business stakeholders
-tr report generate scan.json \
+tradar report generate scan.json \
   -o exec-report.md \
   -f markdown \
   --level executive \
   --ai-provider openai
 
 # Summary level - For security team quick reviews
-tr report generate scan.json \
+tradar report generate scan.json \
   -o summary-report.json \
   --level summary
 
 # Detailed level - For technical analysis and remediation planning
-tr report generate scan.json \
+tradar report generate scan.json \
   -o detailed-report.html \
   -f html \
   --level detailed
 
 # Critical-only - For incident response and urgent action
-tr report generate scan.json \
+tradar report generate scan.json \
   -o critical-report.json \
   --level critical-only
 ```
@@ -1338,22 +1338,22 @@ tr report generate scan.json \
 
 ```bash
 # Use OpenAI for executive summaries
-tr report generate scan.json \
+tradar report generate scan.json \
   --ai-provider openai \
   --ai-model gpt-4o
 
 # Use Anthropic Claude for deeper analysis
-tr report generate scan.json \
+tradar report generate scan.json \
   --ai-provider anthropic \
   --ai-model claude-3-5-sonnet-20241022
 
 # Use local Ollama for privacy
-tr report generate scan.json \
+tradar report generate scan.json \
   --ai-provider ollama \
   --ai-model llama2
 
 # Disable AI for faster generation
-tr report generate scan.json \
+tradar report generate scan.json \
   --no-executive
 ```
 
@@ -1361,11 +1361,11 @@ tr report generate scan.json \
 
 ```bash
 # Include/exclude dashboard data
-tr report generate scan.json --dashboard  # Include (default)
-tr report generate scan.json --no-dashboard  # Exclude
+tradar report generate scan.json --dashboard  # Include (default)
+tradar report generate scan.json --no-dashboard  # Exclude
 
 # Export custom dashboard metrics only
-tr report dashboard-export scan.json -o custom-dashboard.json
+tradar report dashboard-export scan.json -o custom-dashboard.json
 ```
 
 **Format-Specific Customization:**
@@ -1387,9 +1387,9 @@ Automate security reporting with cron jobs, CI/CD pipelines, and custom workflow
 # Add to crontab: crontab -e
 
 # Daily vulnerability scan and report (2 AM)
-0 2 * * * /usr/local/bin/tr cve scan-image myapp:latest \
+0 2 * * * /usr/local/bin/tradar cve scan-image myapp:latest \
   --auto-save && \
-  /usr/local/bin/tr report generate \
+  /usr/local/bin/tradar report generate \
   storage/cve_storage/myapp_latest_image_*.json \
   -o /var/reports/daily-$(date +\%Y\%m\%d).html \
   -f html --level summary
@@ -1401,9 +1401,9 @@ Automate security reporting with cron jobs, CI/CD pipelines, and custom workflow
 0 8 1 * * /home/user/scripts/monthly-compliance.sh
 
 # Hourly critical-only scan for production (business hours)
-0 9-17 * * 1-5 /usr/local/bin/tr cve scan-image prod:latest \
+0 9-17 * * 1-5 /usr/local/bin/tradar cve scan-image prod:latest \
   --auto-save && \
-  /usr/local/bin/tr report generate \
+  /usr/local/bin/tradar report generate \
   storage/cve_storage/prod_latest_*.json \
   --level critical-only \
   -o /var/reports/critical-$(date +\%Y\%m\%d-\%H\%M).json
@@ -1431,7 +1431,7 @@ jobs:
       - name: Scan all production images
         run: |
           for image in frontend:prod backend:prod api:prod; do
-            tr cve scan-image $image \
+            tradar cve scan-image $image \
               --auto-save -o scan-${image/:/-}.json
           done
 
@@ -1439,7 +1439,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          tr report generate scan-*.json \
+          tradar report generate scan-*.json \
             -o weekly-report.html \
             -f html \
             --level detailed \
@@ -1449,7 +1449,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          tr report generate scan-*.json \
+          tradar report generate scan-*.json \
             -o executive-summary.md \
             -f markdown \
             --level executive \
@@ -1457,7 +1457,7 @@ jobs:
 
       - name: Export dashboard data
         run: |
-          tr report dashboard-export scan-*.json \
+          tradar report dashboard-export scan-*.json \
             -o dashboard-metrics.json
 
       - name: Upload reports to S3
@@ -1517,7 +1517,7 @@ pipeline {
 
                     images.each { image ->
                         sh """
-                            tr cve scan-image ${image} \
+                            tradar cve scan-image ${image} \
                                 --auto-save \
                                 -o scan-${image.replaceAll(':', '-')}.json
                         """
@@ -1531,7 +1531,7 @@ pipeline {
                 stage('Technical Report') {
                     steps {
                         sh '''
-                            tr report generate scan-*.json \
+                            tradar report generate scan-*.json \
                                 -o technical-report.html \
                                 -f html \
                                 --level detailed
@@ -1542,7 +1542,7 @@ pipeline {
                 stage('Executive Report') {
                     steps {
                         sh '''
-                            tr report generate scan-*.json \
+                            tradar report generate scan-*.json \
                                 -o executive-report.md \
                                 -f markdown \
                                 --level executive \
@@ -1554,7 +1554,7 @@ pipeline {
                 stage('Dashboard Export') {
                     steps {
                         sh '''
-                            tr report dashboard-export scan-*.json \
+                            tradar report dashboard-export scan-*.json \
                                 -o dashboard-data.json
                         '''
                     }
@@ -1745,10 +1745,10 @@ Track vulnerability changes over time:
 
 ```bash
 # Compare two scan results
-tr report compare old-scan.json new-scan.json
+tradar report compare old-scan.json new-scan.json
 
 # Save comparison report
-tr report compare baseline.json current.json -o comparison.json
+tradar report compare baseline.json current.json -o comparison.json
 ```
 
 **Comparison shows:**
@@ -1770,17 +1770,17 @@ WEEK=$(date +%Y-W%U)
 IMAGE="myapp:production"
 
 # 1. Scan production Docker image
-tr cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
+tradar cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
 
 # 2. Build vulnerability graph
-tr graph build scan-${WEEK}.json --auto-save -o graph-${WEEK}.graphml
+tradar graph build scan-${WEEK}.json --auto-save -o graph-${WEEK}.graphml
 
 # 3. Discover attack paths
-tr graph attack-paths graph-${WEEK}.graphml \
+tradar graph attack-paths graph-${WEEK}.graphml \
   --max-paths 30 -o attack-paths-${WEEK}.json
 
 # 4. Generate comprehensive HTML report for security team with attack paths
-tr report generate scan-${WEEK}.json \
+tradar report generate scan-${WEEK}.json \
   -o reports/detailed-${WEEK}.html \
   -f html \
   --level detailed \
@@ -1788,7 +1788,7 @@ tr report generate scan-${WEEK}.json \
   --ai-provider openai
 
 # 5. Generate executive PDF summary for leadership meeting
-tr report generate scan-${WEEK}.json \
+tradar report generate scan-${WEEK}.json \
   -o reports/exec-${WEEK}.pdf \
   -f pdf \
   --level executive \
@@ -1796,12 +1796,12 @@ tr report generate scan-${WEEK}.json \
   --ai-provider openai
 
 # 6. Export dashboard data for Grafana monitoring
-tr report dashboard-export scan-${WEEK}.json \
+tradar report dashboard-export scan-${WEEK}.json \
   -o dashboards/metrics-${WEEK}.json
 
 # 7. Compare with last week's scan
 if [ -f "scan-${LAST_WEEK}.json" ]; then
-  tr report compare \
+  tradar report compare \
     scan-${LAST_WEEK}.json \
     scan-${WEEK}.json \
     -o reports/trend-${WEEK}.json
@@ -1847,14 +1847,14 @@ jobs:
 
       - name: Scan for vulnerabilities
         run: |
-          tr cve scan-image app:${{ github.sha }} \
+          tradar cve scan-image app:${{ github.sha }} \
             -o scan-results.json \
             --auto-save \
             --cleanup
 
       - name: Generate critical-only report
         run: |
-          tr report generate scan-results.json \
+          tradar report generate scan-results.json \
             -o critical-report.json \
             --level critical-only
 
@@ -1874,18 +1874,18 @@ jobs:
 
       - name: Build vulnerability graph
         run: |
-          tr graph build scan-results.json \
+          tradar graph build scan-results.json \
             --auto-save -o vuln-graph.graphml
 
       - name: Discover attack paths
         run: |
-          tr graph attack-paths vuln-graph.graphml \
+          tradar graph attack-paths vuln-graph.graphml \
             --max-paths 20 -o attack-paths.json
 
       - name: Generate PR comment report with attack paths
         if: github.event_name == 'pull_request'
         run: |
-          tr report generate scan-results.json \
+          tradar report generate scan-results.json \
             -o pr-report.md \
             -f markdown \
             --level summary \
@@ -1899,7 +1899,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          tr report generate scan-results.json \
+          tradar report generate scan-results.json \
             -o executive-report.pdf \
             -f pdf \
             --level executive \
@@ -1941,19 +1941,19 @@ for IMAGE in "${IMAGES[@]}"; do
   SAFE_NAME="${IMAGE//:/─}"
 
   # Scan for vulnerabilities
-  tr cve scan-image $IMAGE \
+  tradar cve scan-image $IMAGE \
     -o "compliance/${SAFE_NAME}-${QUARTER}.json" \
     --auto-save
 
   # Build graph and find attack paths
-  tr graph build "compliance/${SAFE_NAME}-${QUARTER}.json" \
+  tradar graph build "compliance/${SAFE_NAME}-${QUARTER}.json" \
     -o "compliance/${SAFE_NAME}-graph.graphml"
 
-  tr graph attack-paths "compliance/${SAFE_NAME}-graph.graphml" \
+  tradar graph attack-paths "compliance/${SAFE_NAME}-graph.graphml" \
     --max-paths 30 -o "compliance/${SAFE_NAME}-paths.json"
 
   # Generate detailed HTML report with attack paths
-  tr report generate \
+  tradar report generate \
     "compliance/${SAFE_NAME}-${QUARTER}.json" \
     -o "compliance/${SAFE_NAME}-${QUARTER}.html" \
     -f html \
@@ -1962,7 +1962,7 @@ for IMAGE in "${IMAGES[@]}"; do
     --ai-provider openai
 
   # Generate executive PDF for auditors
-  tr report generate \
+  tradar report generate \
     "compliance/${SAFE_NAME}-${QUARTER}.json" \
     -o "compliance/${SAFE_NAME}-${QUARTER}.pdf" \
     -f pdf \
@@ -2121,21 +2121,21 @@ Threat Radar supports multiple export formats for reports and visualizations:
 
 ```bash
 # Export as JSON (default) - Best for automation
-tr report generate scan.json -o report.json -f json
+tradar report generate scan.json -o report.json -f json
 
 # Export as Markdown - Best for documentation
-tr report generate scan.json -o report.md -f markdown
+tradar report generate scan.json -o report.md -f markdown
 
 # Export as HTML - Best for presentations
-tr report generate scan.json -o report.html -f html
+tradar report generate scan.json -o report.html -f html
 
 # Export as PDF - Best for executives and printing
-tr report generate scan.json -o report.pdf -f pdf
+tradar report generate scan.json -o report.pdf -f pdf
 
 # Auto-detect format from file extension
-tr report generate scan.json -o report.html  # Automatically uses HTML
-tr report generate scan.json -o report.md    # Automatically uses Markdown
-tr report generate scan.json -o report.pdf   # Automatically uses PDF
+tradar report generate scan.json -o report.html  # Automatically uses HTML
+tradar report generate scan.json -o report.md    # Automatically uses Markdown
+tradar report generate scan.json -o report.pdf   # Automatically uses PDF
 ```
 
 **Note:** PDF export requires weasyprint:
@@ -2143,7 +2143,7 @@ tr report generate scan.json -o report.pdf   # Automatically uses PDF
 # Install weasyprint for PDF export
 pip install weasyprint
 
-# Or install tr with PDF support
+# Or install tradar with PDF support
 pip install threat-radar[pdf]
 ```
 
@@ -2153,7 +2153,7 @@ Dashboard data is exported in JSON format optimized for visualization tools:
 
 ```bash
 # Export dashboard data for Grafana
-tr report dashboard-export scan.json -o dashboard.json
+tradar report dashboard-export scan.json -o dashboard.json
 
 # Dashboard data structure includes:
 # - Summary cards (total vulnerabilities, critical count, CVSS scores)
@@ -2168,14 +2168,14 @@ tr report dashboard-export scan.json -o dashboard.json
 
 ```bash
 # Export for Grafana dashboard
-tr report dashboard-export scan.json -o /var/grafana/data/security-metrics.json
+tradar report dashboard-export scan.json -o /var/grafana/data/security-metrics.json
 
 # Export for custom web dashboard
-tr report dashboard-export scan.json | \
+tradar report dashboard-export scan.json | \
   curl -X POST https://dashboard.company.com/api/metrics -d @-
 
 # Export for Splunk/ELK
-tr report generate scan.json -f json | \
+tradar report generate scan.json -f json | \
   curl -X POST https://splunk.company.com:8088/services/collector -d @-
 ```
 
@@ -2196,16 +2196,16 @@ Graph visualizations support multiple export formats via the `visualize export` 
 
 ```bash
 # Export graph visualization as HTML
-tr visualize export graph.graphml -o viz.html --format html
+tradar visualize export graph.graphml -o viz.html --format html
 
 # Export as high-resolution PNG
-tr visualize export graph.graphml -o viz.png --format png
+tradar visualize export graph.graphml -o viz.png --format png
 
 # Export as PDF for reports
-tr visualize export graph.graphml -o viz.pdf --format pdf
+tradar visualize export graph.graphml -o viz.pdf --format pdf
 
 # Export multiple formats at once
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format html --format png --format pdf
 ```
 
@@ -2225,28 +2225,28 @@ echo "Generating complete security report suite for $TARGET..."
 
 # 1. Scan for vulnerabilities
 echo "Step 1: Scanning for vulnerabilities..."
-tr cve scan-image $TARGET --auto-save -o scan.json
+tradar cve scan-image $TARGET --auto-save -o scan.json
 
 # 2. Build graph and analyze attack paths
 echo "Step 2: Building vulnerability graph..."
-tr graph build scan.json --auto-save -o graph.graphml
+tradar graph build scan.json --auto-save -o graph.graphml
 
 echo "Step 3: Discovering attack paths..."
-tr graph attack-paths graph.graphml \
+tradar graph attack-paths graph.graphml \
   --max-paths 30 -o attack-paths.json
 
 # 3. Export reports in all formats with attack paths
 echo "Step 4: Generating reports in all formats..."
 
 # JSON - For automation
-tr report generate scan.json \
+tradar report generate scan.json \
   -o $REPORT_DIR/detailed-report.json \
   -f json \
   --level detailed \
   --attack-paths attack-paths.json
 
 # Markdown - For documentation
-tr report generate scan.json \
+tradar report generate scan.json \
   -o $REPORT_DIR/executive-summary.md \
   -f markdown \
   --level executive \
@@ -2254,14 +2254,14 @@ tr report generate scan.json \
   --ai-provider openai
 
 # HTML - For presentations
-tr report generate scan.json \
+tradar report generate scan.json \
   -o $REPORT_DIR/technical-report.html \
   -f html \
   --level detailed \
   --attack-paths attack-paths.json
 
 # PDF - For executives and printing
-tr report generate scan.json \
+tradar report generate scan.json \
   -o $REPORT_DIR/executive-report.pdf \
   -f pdf \
   --level executive \
@@ -2270,16 +2270,16 @@ tr report generate scan.json \
 
 # 4. Export dashboard data
 echo "Step 5: Exporting dashboard data..."
-tr report dashboard-export scan.json \
+tradar report dashboard-export scan.json \
   -o $REPORT_DIR/dashboard-data.json
 
 # 5. Export visualizations
 echo "Step 6: Creating visualizations..."
-tr visualize export graph.graphml \
+tradar visualize export graph.graphml \
   -o $REPORT_DIR/graph-viz \
   --format html --format png --format pdf
 
-tr visualize attack-paths graph.graphml \
+tradar visualize attack-paths graph.graphml \
   -o $REPORT_DIR/attack-paths-viz.html \
   --paths attack-paths.json
 
@@ -2306,15 +2306,15 @@ echo "Archive: security-report-${DATE}.tar.gz"
 
 ```bash
 # Upload to AWS S3
-tr report generate scan.json -o report.html -f html
+tradar report generate scan.json -o report.html -f html
 aws s3 cp report.html s3://security-reports/$(date +%Y/%m/%d)/
 
 # Upload to Google Cloud Storage
-tr report generate scan.json -o report.json -f json
+tradar report generate scan.json -o report.json -f json
 gsutil cp report.json gs://security-reports/$(date +%Y/%m/%d)/
 
 # Upload to Azure Blob Storage
-tr report generate scan.json -o report.md -f markdown
+tradar report generate scan.json -o report.md -f markdown
 az storage blob upload \
   --container-name security-reports \
   --name $(date +%Y/%m/%d)/report.md \
@@ -2447,19 +2447,19 @@ if __name__ == "__main__":
 
 ```bash
 # Import and analyze an image
-tr docker import-image alpine:3.18 -o analysis.json
+tradar docker import-image alpine:3.18 -o analysis.json
 
 # Scan existing local image
-tr docker scan ubuntu:22.04
+tradar docker scan ubuntu:22.04
 
 # List all local Docker images
-tr docker list-images
+tradar docker list-images
 
 # List packages in an image
-tr docker packages alpine:3.18 --limit 20 --filter openssl
+tradar docker packages alpine:3.18 --limit 20 --filter openssl
 
 # Generate Python SBOM
-tr docker python-sbom python:3.11 -o sbom.json --format cyclonedx
+tradar docker python-sbom python:3.11 -o sbom.json --format cyclonedx
 ```
 
 ## Graph Commands Reference
@@ -2479,49 +2479,49 @@ The graph database integration provides relationship-based vulnerability analysi
 
 ```bash
 # Build graph from CVE scan results
-tr graph build scan-results.json -o vulnerability-graph.graphml
+tradar graph build scan-results.json -o vulnerability-graph.graphml
 
 # Auto-save to storage/graph_storage/
-tr graph build scan-results.json --auto-save
+tradar graph build scan-results.json --auto-save
 
 # Example workflow: Scan and build graph
-tr cve scan-image alpine:3.18 --auto-save -o scan.json
-tr graph build scan.json --auto-save
+tradar cve scan-image alpine:3.18 --auto-save -o scan.json
+tradar graph build scan.json --auto-save
 ```
 
 ### Graph Querying
 
 ```bash
 # Find containers affected by a CVE (blast radius)
-tr graph query graph.graphml --cve CVE-2023-1234
+tradar graph query graph.graphml --cve CVE-2023-1234
 
 # Show top 10 most vulnerable packages
-tr graph query graph.graphml --top-packages 10
+tradar graph query graph.graphml --top-packages 10
 
 # Display vulnerability statistics
-tr graph query graph.graphml --stats
+tradar graph query graph.graphml --stats
 
 # Combined query
-tr graph query graph.graphml --cve CVE-2023-1234 --stats
+tradar graph query graph.graphml --cve CVE-2023-1234 --stats
 ```
 
 ### Graph Management
 
 ```bash
 # List all stored graphs
-tr graph list
-tr graph list --limit 10
+tradar graph list
+tradar graph list --limit 10
 
 # Show detailed graph information
-tr graph info graph.graphml
+tradar graph info graph.graphml
 
 # Find vulnerabilities with available fixes
-tr graph fixes graph.graphml
-tr graph fixes graph.graphml --severity critical
+tradar graph fixes graph.graphml
+tradar graph fixes graph.graphml --severity critical
 
 # Clean up old graphs
-tr graph cleanup --days 30
-tr graph cleanup --days 30 --force
+tradar graph cleanup --days 30
+tradar graph cleanup --days 30 --force
 ```
 
 ### Graph Architecture
@@ -2563,24 +2563,24 @@ du -sh storage/graph_storage/
 
 ```bash
 # 1. Scan multiple images
-tr cve scan-image alpine:3.18 --auto-save -o alpine-scan.json
-tr cve scan-image python:3.11 --auto-save -o python-scan.json
-tr cve scan-image nginx:alpine --auto-save -o nginx-scan.json
+tradar cve scan-image alpine:3.18 --auto-save -o alpine-scan.json
+tradar cve scan-image python:3.11 --auto-save -o python-scan.json
+tradar cve scan-image nginx:alpine --auto-save -o nginx-scan.json
 
 # 2. Build graphs
-tr graph build alpine-scan.json --auto-save
-tr graph build python-scan.json --auto-save
-tr graph build nginx-scan.json --auto-save
+tradar graph build alpine-scan.json --auto-save
+tradar graph build python-scan.json --auto-save
+tradar graph build nginx-scan.json --auto-save
 
 # 3. Analyze vulnerability landscape
-tr graph list
-tr graph query latest-graph.graphml --stats
+tradar graph list
+tradar graph query latest-graph.graphml --stats
 
 # 4. Find critical CVE impact
-tr graph query latest-graph.graphml --cve CVE-2023-XXXX
+tradar graph query latest-graph.graphml --cve CVE-2023-XXXX
 
 # 5. Identify fix candidates
-tr graph fixes latest-graph.graphml --severity critical
+tradar graph fixes latest-graph.graphml --severity critical
 
 # 6. Export for custom dashboards
 # Graphs are in GraphML format, compatible with:
@@ -2623,9 +2623,9 @@ storage.save_graph(client, "my-analysis")
 **1. Vulnerability Trend Analysis**
 ```bash
 # Build graphs over time
-tr graph build scan-week1.json -o week1.graphml
-tr graph build scan-week2.json -o week2.graphml
-tr graph build scan-week3.json -o week3.graphml
+tradar graph build scan-week1.json -o week1.graphml
+tradar graph build scan-week2.json -o week2.graphml
+tradar graph build scan-week3.json -o week3.graphml
 
 # Compare graphs programmatically to track improvements
 ```
@@ -2634,8 +2634,8 @@ tr graph build scan-week3.json -o week3.graphml
 ```bash
 # Scan entire stack
 for image in frontend:latest backend:latest api:latest; do
-  tr cve scan-image $image --auto-save -o ${image//:/─}-scan.json
-  tr graph build ${image//:/─}-scan.json --auto-save
+  tradar cve scan-image $image --auto-save -o ${image//:/─}-scan.json
+  tradar graph build ${image//:/─}-scan.json --auto-save
 done
 
 # Analyze shared vulnerabilities across containers
@@ -2644,9 +2644,9 @@ done
 **3. CI/CD Integration**
 ```bash
 # Pipeline: Fail if critical vulnerabilities found
-tr cve scan-image $IMAGE --auto-save -o scan.json
-tr graph build scan.json -o graph.graphml
-tr graph fixes graph.graphml --severity critical > critical-fixes.txt
+tradar cve scan-image $IMAGE --auto-save -o scan.json
+tradar graph build scan.json -o graph.graphml
+tradar graph fixes graph.graphml --severity critical > critical-fixes.txt
 
 if [ -s critical-fixes.txt ]; then
   echo "CRITICAL vulnerabilities found!"
@@ -2664,10 +2664,10 @@ Discover shortest attack paths from entry points to high-value targets:
 
 ```bash
 # Find attack paths in a graph
-tr graph attack-paths graph.graphml
+tradar graph attack-paths graph.graphml
 
 # Limit number of paths and save to JSON
-tr graph attack-paths graph.graphml \
+tradar graph attack-paths graph.graphml \
   --max-paths 20 \
   --max-length 10 \
   -o attack-paths.json
@@ -2692,10 +2692,10 @@ Identify opportunities for attackers to escalate privileges:
 
 ```bash
 # Find privilege escalation paths
-tr graph privilege-escalation graph.graphml
+tradar graph privilege-escalation graph.graphml
 
 # Limit results and save output
-tr graph privilege-escalation graph.graphml \
+tradar graph privilege-escalation graph.graphml \
   --max-paths 20 \
   -o privilege-escalation.json
 
@@ -2718,10 +2718,10 @@ Find lateral movement opportunities within the infrastructure:
 
 ```bash
 # Identify lateral movement opportunities
-tr graph lateral-movement graph.graphml
+tradar graph lateral-movement graph.graphml
 
 # Customize search parameters
-tr graph lateral-movement graph.graphml \
+tradar graph lateral-movement graph.graphml \
   --max-opportunities 30 \
   -o lateral-movement.json
 
@@ -2744,10 +2744,10 @@ Combine all attack path analysis into a complete security assessment:
 
 ```bash
 # Full attack surface analysis
-tr graph attack-surface graph.graphml
+tradar graph attack-surface graph.graphml
 
 # Comprehensive analysis with custom limits
-tr graph attack-surface graph.graphml \
+tradar graph attack-surface graph.graphml \
   --max-paths 50 \
   -o attack-surface.json
 
@@ -2775,27 +2775,27 @@ tr graph attack-surface graph.graphml \
 # complete-attack-analysis.sh
 
 # 1. Build environment graph with vulnerability data
-tr env build-graph production-env.json \
+tradar env build-graph production-env.json \
   --merge-scan scan-results-1.json \
   --merge-scan scan-results-2.json \
   -o complete-graph.graphml
 
 # 2. Analyze all attack vectors
-tr graph attack-surface complete-graph.graphml \
+tradar graph attack-surface complete-graph.graphml \
   -o attack-surface.json
 
 # 3. Find critical attack paths
-tr graph attack-paths complete-graph.graphml \
+tradar graph attack-paths complete-graph.graphml \
   --max-paths 50 \
   -o critical-paths.json
 
 # 4. Detect privilege escalation opportunities
-tr graph privilege-escalation complete-graph.graphml \
+tradar graph privilege-escalation complete-graph.graphml \
   --max-paths 20 \
   -o privesc.json
 
 # 5. Identify lateral movement risks
-tr graph lateral-movement complete-graph.graphml \
+tradar graph lateral-movement complete-graph.graphml \
   --max-opportunities 30 \
   -o lateral.json
 
@@ -2814,7 +2814,7 @@ jq -r '.recommendations[]' attack-surface.json
 GRAPH="production-graph.graphml"
 
 # Find all critical-severity attack paths
-tr graph attack-paths $GRAPH -o paths.json
+tradar graph attack-paths $GRAPH -o paths.json
 
 # Extract critical paths
 CRITICAL=$(jq -r '.attack_paths[] | select(.threat_level=="critical") | .path_id' paths.json)
@@ -2849,9 +2849,9 @@ BASELINE="baseline-attack-surface.json"
 CURRENT="current-attack-surface.json"
 
 # Scan current state
-tr cve scan-image production:latest --auto-save -o scan.json
-tr graph build scan.json -o graph.graphml
-tr graph attack-surface graph.graphml -o $CURRENT
+tradar cve scan-image production:latest --auto-save -o scan.json
+tradar graph build scan.json -o graph.graphml
+tradar graph attack-surface graph.graphml -o $CURRENT
 
 # Compare with baseline
 BASELINE_RISK=$(jq -r '.total_risk_score' $BASELINE)
@@ -2894,13 +2894,13 @@ Attack path analysis integrates with environment configuration for business-awar
 ENV_FILE="production-environment.json"
 
 # 1. Build graph with environment context
-tr env build-graph $ENV_FILE \
+tradar env build-graph $ENV_FILE \
   --merge-scan scan1.json \
   --merge-scan scan2.json \
   -o context-graph.graphml
 
 # 2. Find attack paths to critical business assets
-tr graph attack-paths context-graph.graphml -o paths.json
+tradar graph attack-paths context-graph.graphml -o paths.json
 
 # 3. Filter paths targeting PCI-scoped assets
 jq '.attack_paths[] | select(.target | contains("asset-payment"))' paths.json \
@@ -3106,13 +3106,13 @@ Validate environment configuration file syntax and schema:
 
 ```bash
 # Validate configuration file
-tr env validate my-environment.json
+tradar env validate my-environment.json
 
 # Show detailed validation errors
-tr env validate my-environment.json --errors
+tradar env validate my-environment.json --errors
 
 # Validate and show risk summary
-tr env validate production-env.json
+tradar env validate production-env.json
 ```
 
 **Validation checks:**
@@ -3145,13 +3145,13 @@ Build graph database from environment configuration:
 
 ```bash
 # Build graph from environment config
-tr env build-graph my-environment.json -o infrastructure.graphml
+tradar env build-graph my-environment.json -o infrastructure.graphml
 
 # Auto-save to storage/graph_storage/
-tr env build-graph production-env.json --auto-save
+tradar env build-graph production-env.json --auto-save
 
 # Merge with vulnerability scan results
-tr env build-graph my-environment.json \
+tradar env build-graph my-environment.json \
   --merge-scan scan-results-1.json \
   --merge-scan scan-results-2.json \
   --auto-save
@@ -3174,18 +3174,18 @@ tr env build-graph my-environment.json \
 **Use cases:**
 ```bash
 # Build infrastructure topology graph
-tr env build-graph production.json --auto-save
+tradar env build-graph production.json --auto-save
 
 # Merge infrastructure with vulnerability scans
-tr cve scan-image payment-api:v2.1.0 -o scan1.json
-tr cve scan-image frontend:latest -o scan2.json
-tr env build-graph production.json \
+tradar cve scan-image payment-api:v2.1.0 -o scan1.json
+tradar cve scan-image frontend:latest -o scan2.json
+tradar env build-graph production.json \
   --merge-scan scan1.json \
   --merge-scan scan2.json \
   -o complete-risk-graph.graphml
 
 # Query merged graph for business-context-aware analysis
-tr graph query complete-risk-graph.graphml --stats
+tradar graph query complete-risk-graph.graphml --stats
 ```
 
 #### Analyze Risk with Business Context
@@ -3194,18 +3194,18 @@ Perform AI-powered risk analysis incorporating business context:
 
 ```bash
 # Analyze vulnerabilities with business context
-tr env analyze-risk my-environment.json scan-results.json
+tradar env analyze-risk my-environment.json scan-results.json
 
 # Use specific AI provider
-tr env analyze-risk production.json scan.json \
+tradar env analyze-risk production.json scan.json \
   --ai-provider anthropic \
   --ai-model claude-3-5-sonnet-20241022
 
 # Save analysis results
-tr env analyze-risk env.json scan.json -o risk-analysis.json
+tradar env analyze-risk env.json scan.json -o risk-analysis.json
 
 # Auto-save to storage/ai_analysis/
-tr env analyze-risk production.json scan.json --auto-save
+tradar env analyze-risk production.json scan.json --auto-save
 ```
 
 **Business context-aware analysis includes:**
@@ -3274,7 +3274,7 @@ ENV_FILE="production-environment.json"
 
 # 1. Validate environment configuration
 echo "Validating environment configuration..."
-tr env validate $ENV_FILE
+tradar env validate $ENV_FILE
 
 # 2. Scan all assets for vulnerabilities
 echo "Scanning assets..."
@@ -3282,23 +3282,23 @@ SCANS=()
 for asset in $(jq -r '.assets[].software.image' $ENV_FILE | grep -v null); do
   echo "  Scanning $asset..."
   scan_file="scan-${asset//[:\/]/_}.json"
-  tr cve scan-image $asset --auto-save -o $scan_file
+  tradar cve scan-image $asset --auto-save -o $scan_file
   SCANS+=("--merge-scan $scan_file")
 done
 
 # 3. Build infrastructure graph with vulnerabilities
 echo "Building infrastructure graph..."
-tr env build-graph $ENV_FILE ${SCANS[@]} --auto-save
+tradar env build-graph $ENV_FILE ${SCANS[@]} --auto-save
 
 # 4. Perform business context-aware risk analysis
 echo "Analyzing risk with business context..."
 for scan in scan-*.json; do
-  tr env analyze-risk $ENV_FILE $scan --auto-save
+  tradar env analyze-risk $ENV_FILE $scan --auto-save
 done
 
 # 5. Generate executive report
 echo "Generating executive report..."
-tr report generate scan-*.json \
+tradar report generate scan-*.json \
   -o executive-risk-report.html \
   -f html \
   --level executive \
@@ -3330,17 +3330,17 @@ jobs:
 
       - name: Scan for Vulnerabilities
         run: |
-          tr cve scan-image app:${{ github.sha }} \
+          tradar cve scan-image app:${{ github.sha }} \
             --auto-save -o scan.json
 
       - name: Validate Environment Config
-        run: tr env validate .threat-radar/production-env.json
+        run: tradar env validate .threat-radar/production-env.json
 
       - name: Analyze with Business Context
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          tr env analyze-risk \
+          tradar env analyze-risk \
             .threat-radar/production-env.json \
             scan.json \
             -o risk-analysis.json
@@ -3371,19 +3371,19 @@ jq -r '.assets[] | select(.business_context.pci_scope == true) | .software.image
 while read -r image; do
   if [ -n "$image" ]; then
     echo "  Scanning $image..."
-    tr cve scan-image $image --auto-save
+    tradar cve scan-image $image --auto-save
   fi
 done
 
 # Build infrastructure graph with scans
 echo "Building compliance risk graph..."
-tr env build-graph $ENV_FILE \
+tradar env build-graph $ENV_FILE \
   --merge-scan storage/cve_storage/*.json \
   -o compliance-risk-${QUARTER}.graphml
 
 # Generate compliance report
 echo "Generating compliance report..."
-tr env analyze-risk $ENV_FILE storage/cve_storage/*.json \
+tradar env analyze-risk $ENV_FILE storage/cve_storage/*.json \
   -o compliance-report-${QUARTER}.json \
   --ai-provider openai
 
@@ -3749,28 +3749,28 @@ Create interactive vulnerability graph visualizations:
 
 ```bash
 # Create basic interactive graph
-tr visualize graph graph.graphml -o visualization.html
+tradar visualize graph graph.graphml -o visualization.html
 
 # Open visualization in browser automatically
-tr visualize graph graph.graphml -o viz.html --open
+tradar visualize graph graph.graphml -o viz.html --open
 
 # Use different layout algorithm
-tr visualize graph graph.graphml -o viz.html \
+tradar visualize graph graph.graphml -o viz.html \
   --layout hierarchical
 
 # Color by severity instead of node type
-tr visualize graph graph.graphml -o viz.html \
+tradar visualize graph graph.graphml -o viz.html \
   --color-by severity
 
 # Create 3D visualization
-tr visualize graph graph.graphml -o viz.html --3d
+tradar visualize graph graph.graphml -o viz.html --3d
 
 # Custom dimensions
-tr visualize graph graph.graphml -o viz.html \
+tradar visualize graph graph.graphml -o viz.html \
   --width 1600 --height 1000
 
 # Hide node labels for cleaner view
-tr visualize graph graph.graphml -o viz.html --no-labels
+tradar visualize graph graph.graphml -o viz.html --no-labels
 ```
 
 **Layout algorithms:**
@@ -3790,22 +3790,22 @@ Visualize attack paths with highlighted routes:
 
 ```bash
 # Visualize attack paths from graph analysis
-tr visualize attack-paths graph.graphml -o attack-paths.html
+tradar visualize attack-paths graph.graphml -o attack-paths.html
 
 # Use pre-calculated attack paths JSON
-tr visualize attack-paths graph.graphml -o paths.html \
+tradar visualize attack-paths graph.graphml -o paths.html \
   --paths attack-paths.json
 
 # Show only top 10 most critical paths
-tr visualize attack-paths graph.graphml -o paths.html \
+tradar visualize attack-paths graph.graphml -o paths.html \
   --max-paths 10
 
 # Hierarchical layout for clearer attack flows
-tr visualize attack-paths graph.graphml -o paths.html \
+tradar visualize attack-paths graph.graphml -o paths.html \
   --layout hierarchical
 
 # Custom dimensions for presentation
-tr visualize attack-paths graph.graphml -o paths.html \
+tradar visualize attack-paths graph.graphml -o paths.html \
   --width 1920 --height 1080 --open
 ```
 
@@ -3822,26 +3822,26 @@ Visualize network topology with security context:
 
 ```bash
 # Basic topology visualization
-tr visualize topology graph.graphml -o topology.html
+tradar visualize topology graph.graphml -o topology.html
 
 # Security zones view
-tr visualize topology graph.graphml -o zones.html \
+tradar visualize topology graph.graphml -o zones.html \
   --view zones
 
 # Compliance scope view
-tr visualize topology graph.graphml -o compliance.html \
+tradar visualize topology graph.graphml -o compliance.html \
   --view compliance
 
 # Specific compliance type (PCI-DSS)
-tr visualize topology graph.graphml -o pci.html \
+tradar visualize topology graph.graphml -o pci.html \
   --view compliance --compliance pci
 
 # Color by criticality
-tr visualize topology graph.graphml -o topology.html \
+tradar visualize topology graph.graphml -o topology.html \
   --color-by criticality
 
 # Color by compliance scope
-tr visualize topology graph.graphml -o topology.html \
+tradar visualize topology graph.graphml -o topology.html \
   --color-by compliance
 ```
 
@@ -3861,43 +3861,43 @@ Apply filters to focus on specific graph subsets:
 
 ```bash
 # Filter by severity (show only HIGH+ vulnerabilities)
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type severity --value high
 
 # Filter by node type (show only vulnerabilities and packages)
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type node_type --values vulnerability package
 
 # Filter by specific CVE
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type cve --values CVE-2023-1234 CVE-2023-5678
 
 # Filter by package name
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type package --values openssl curl
 
 # Filter by security zone
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type zone --values dmz internal
 
 # Filter by criticality
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type criticality --value critical
 
 # Filter by compliance scope
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type compliance --values pci hipaa
 
 # Filter internet-facing assets only
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type internet_facing
 
 # Search for specific terms
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type search --value "openssl"
 
 # Exclude related nodes (show only filtered nodes)
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type severity --value critical --no-related
 ```
 
@@ -3918,43 +3918,43 @@ Export visualizations to various formats:
 
 ```bash
 # Export as HTML only
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format html
 
 # Export as PNG image
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format png
 
 # Export as high-resolution SVG
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format svg
 
 # Export as PDF for reports
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format pdf
 
 # Export as JSON for web applications
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format json
 
 # Export as DOT for Graphviz
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format dot
 
 # Export as Cytoscape.js format
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format cytoscape
 
 # Export as GEXF for Gephi
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format gexf
 
 # Export multiple formats at once
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format html --format png --format json
 
 # Custom layout for exported visualizations
-tr visualize export graph.graphml -o viz \
+tradar visualize export graph.graphml -o viz \
   --format html --format png --layout hierarchical
 ```
 
@@ -3974,7 +3974,7 @@ See available filter values before filtering:
 
 ```bash
 # Show all available filter values
-tr visualize stats graph.graphml
+tradar visualize stats graph.graphml
 ```
 
 **Output includes:**
@@ -3997,29 +3997,29 @@ tr visualize stats graph.graphml
 IMAGE="myapp:production"
 
 # 1. Scan image for vulnerabilities
-tr cve scan-image $IMAGE --auto-save -o scan.json
+tradar cve scan-image $IMAGE --auto-save -o scan.json
 
 # 2. Build vulnerability graph
-tr graph build scan.json --auto-save -o vuln.graphml
+tradar graph build scan.json --auto-save -o vuln.graphml
 
 # 3. Create basic interactive visualization
-tr visualize graph vuln.graphml -o viz-overview.html \
+tradar visualize graph vuln.graphml -o viz-overview.html \
   --layout hierarchical --open
 
 # 4. Analyze attack paths
-tr graph attack-paths vuln.graphml \
+tradar graph attack-paths vuln.graphml \
   --max-paths 20 -o attack-paths.json
 
 # 5. Visualize attack paths
-tr visualize attack-paths vuln.graphml -o viz-attack-paths.html \
+tradar visualize attack-paths vuln.graphml -o viz-attack-paths.html \
   --paths attack-paths.json --max-paths 10
 
 # 6. Create filtered view of critical issues
-tr visualize filter vuln.graphml -o viz-critical.html \
+tradar visualize filter vuln.graphml -o viz-critical.html \
   --type severity --value critical
 
 # 7. Export to multiple formats for reporting
-tr visualize export vuln.graphml -o reports/vuln-graph \
+tradar visualize export vuln.graphml -o reports/vuln-graph \
   --format html --format png --format pdf
 
 echo "✅ Visualization workflow complete!"
@@ -4038,32 +4038,32 @@ echo "   - Reports: reports/vuln-graph.*"
 ENV_FILE="production-environment.json"
 
 # 1. Build environment graph with vulnerability data
-tr env build-graph $ENV_FILE \
+tradar env build-graph $ENV_FILE \
   --merge-scan scan1.json \
   --merge-scan scan2.json \
   --auto-save -o env-graph.graphml
 
 # 2. Create full topology view
-tr visualize topology env-graph.graphml -o topology-full.html \
+tradar visualize topology env-graph.graphml -o topology-full.html \
   --view topology --color-by zone
 
 # 3. Create security zones view
-tr visualize topology env-graph.graphml -o topology-zones.html \
+tradar visualize topology env-graph.graphml -o topology-zones.html \
   --view zones
 
 # 4. Create compliance scope view (PCI-DSS)
-tr visualize topology env-graph.graphml -o topology-pci.html \
+tradar visualize topology env-graph.graphml -o topology-pci.html \
   --view compliance --compliance pci
 
 # 5. Filter to show only internet-facing assets
-tr visualize filter env-graph.graphml -o topology-external.html \
+tradar visualize filter env-graph.graphml -o topology-external.html \
   --type internet_facing
 
 # 6. Analyze attack paths in environment
-tr graph attack-paths env-graph.graphml \
+tradar graph attack-paths env-graph.graphml \
   --max-paths 50 -o env-attack-paths.json
 
-tr visualize attack-paths env-graph.graphml \
+tradar visualize attack-paths env-graph.graphml \
   -o topology-attacks.html --paths env-attack-paths.json
 
 echo "✅ Topology visualization complete!"
@@ -4078,24 +4078,24 @@ echo "✅ Topology visualization complete!"
 GRAPH_FILE="production-graph.graphml"
 
 # Show filter statistics
-tr visualize stats $GRAPH_FILE
+tradar visualize stats $GRAPH_FILE
 
 # Create PCI-DSS compliance view
-tr visualize topology $GRAPH_FILE -o compliance-pci.html \
+tradar visualize topology $GRAPH_FILE -o compliance-pci.html \
   --view compliance --compliance pci
 
-tr visualize filter $GRAPH_FILE -o compliance-pci-critical.html \
+tradar visualize filter $GRAPH_FILE -o compliance-pci-critical.html \
   --type compliance --values pci \
-  | tr visualize filter - -o compliance-pci-critical.html \
+  | tradar visualize filter - -o compliance-pci-critical.html \
     --type severity --value critical
 
 # Create HIPAA compliance view
-tr visualize topology $GRAPH_FILE -o compliance-hipaa.html \
+tradar visualize topology $GRAPH_FILE -o compliance-hipaa.html \
   --view compliance --compliance hipaa
 
 # Export compliance reports
 for compliance in pci hipaa sox gdpr; do
-  tr visualize export $GRAPH_FILE \
+  tradar visualize export $GRAPH_FILE \
     -o reports/compliance-${compliance} \
     --format html --format pdf
 done
@@ -4246,15 +4246,15 @@ For graphs with thousands of nodes:
 
 ```bash
 # Use filtering to reduce graph size
-tr visualize filter graph.graphml -o filtered.html \
+tradar visualize filter graph.graphml -o filtered.html \
   --type severity --value high --no-related
 
 # Or use simpler layout algorithms
-tr visualize graph graph.graphml -o viz.html \
+tradar visualize graph graph.graphml -o viz.html \
   --layout circular --no-labels
 
 # Export as JSON for custom web rendering
-tr visualize export graph.graphml -o data.json \
+tradar visualize export graph.graphml -o data.json \
   --format json
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,44 +13,44 @@ Common development tasks:
 ```bash
 # Setup and verify installation
 pip install -e .
-threat-radar --help
+tr --help
 
 # Run vulnerability scan
-threat-radar cve scan-image alpine:3.18 --auto-save
+tr cve scan-image alpine:3.18 --auto-save
 
 # Use global options for verbose output and JSON format
-threat-radar -vv -f json cve scan-image python:3.11 --auto-save
+tr -vv -f json cve scan-image python:3.11 --auto-save
 
 # Load configuration from custom file
-threat-radar --config ./myconfig.json cve scan-image ubuntu:22.04
+tr --config ./myconfig.json cve scan-image ubuntu:22.04
 
 # Quiet mode for CI/CD (errors only)
-threat-radar -q --no-color cve scan-image myapp:latest --fail-on HIGH
+tr -q --no-color cve scan-image myapp:latest --fail-on HIGH
 
 # Generate SBOM
-threat-radar sbom docker python:3.11 -o sbom.json
+tr sbom docker python:3.11 -o sbom.json
 
 # Run AI analysis (requires API key in .env)
-threat-radar ai analyze scan-results.json --auto-save
+tr ai analyze scan-results.json --auto-save
 
 # Generate comprehensive report
-threat-radar report generate scan-results.json -o report.html -f html
+tr report generate scan-results.json -o report.html -f html
 
 # Build vulnerability graph for relationship analysis
-threat-radar graph build scan-results.json --auto-save
-threat-radar graph query graph.graphml --cve CVE-2023-1234
-threat-radar graph query graph.graphml --top-packages 10 --stats
+tr graph build scan-results.json --auto-save
+tr graph query graph.graphml --cve CVE-2023-1234
+tr graph query graph.graphml --top-packages 10 --stats
 
 # Attack path discovery and security analysis
-threat-radar graph attack-paths graph.graphml --max-paths 20 -o paths.json
-threat-radar graph privilege-escalation graph.graphml -o privesc.json
-threat-radar graph lateral-movement graph.graphml -o lateral.json
-threat-radar graph attack-surface graph.graphml -o attack-surface.json
+tr graph attack-paths graph.graphml --max-paths 20 -o paths.json
+tr graph privilege-escalation graph.graphml -o privesc.json
+tr graph lateral-movement graph.graphml -o lateral.json
+tr graph attack-surface graph.graphml -o attack-surface.json
 
 # Environment configuration and business context
-threat-radar env validate my-environment.json
-threat-radar env build-graph production.json --auto-save
-threat-radar env analyze-risk production.json scan-results.json --auto-save
+tr env validate my-environment.json
+tr env build-graph production.json --auto-save
+tr env analyze-risk production.json scan-results.json --auto-save
 
 # Run tests
 pytest                                    # All tests
@@ -85,10 +85,10 @@ The package provides two CLI entry points:
 
 ```bash
 # Available commands
-threat-radar --help
-threat-radar cve --help
-threat-radar docker --help
-threat-radar sbom --help
+tr --help
+tr cve --help
+tr docker --help
+tr sbom --help
 ```
 
 ### Testing
@@ -131,7 +131,7 @@ flake8 threat_radar/
 All Threat Radar commands support global options that control behavior across the entire CLI:
 
 ```bash
-threat-radar [OPTIONS] COMMAND [ARGS]
+tr [OPTIONS] COMMAND [ARGS]
 
 Global Options:
   -c, --config PATH        Path to configuration file (JSON format)
@@ -157,13 +157,13 @@ Control the amount of output and logging:
 **Examples:**
 ```bash
 # Quiet mode for automation
-threat-radar -q cve scan-image alpine:3.18
+tr -q cve scan-image alpine:3.18
 
 # Verbose debugging
-threat-radar -vv cve scan-image python:3.11
+tr -vv cve scan-image python:3.11
 
 # Very verbose with all internal logging
-threat-radar -vvv ai analyze scan.json
+tr -vvv ai analyze scan.json
 ```
 
 ### Configuration File Support
@@ -225,26 +225,26 @@ Threat Radar supports persistent configuration through JSON files. Configuration
 
 ```bash
 # Initialize new configuration file
-threat-radar config init
-threat-radar config init --path ./my-config.json
-threat-radar config init --force  # Overwrite existing
+tr config init
+tr config init --path ./my-config.json
+tr config init --force  # Overwrite existing
 
 # Show current configuration
-threat-radar config show
-threat-radar config show scan.severity
-threat-radar config show ai.provider
+tr config show
+tr config show scan.severity
+tr config show ai.provider
 
 # Modify configuration
-threat-radar config set scan.severity HIGH
-threat-radar config set ai.provider ollama
-threat-radar config set output.verbosity 2
+tr config set scan.severity HIGH
+tr config set ai.provider ollama
+tr config set output.verbosity 2
 
 # Validate configuration file
-threat-radar config validate
-threat-radar config validate ./my-config.json
+tr config validate
+tr config validate ./my-config.json
 
 # Show configuration file locations
-threat-radar config path
+tr config path
 ```
 
 ### Output Formats
@@ -259,13 +259,13 @@ Threat Radar supports multiple output formats for different use cases:
 **Examples:**
 ```bash
 # JSON output for automation
-threat-radar -f json cve scan-image alpine:3.18
+tr -f json cve scan-image alpine:3.18
 
 # CSV output for spreadsheets
-threat-radar -f csv sbom components sbom.json -o packages.csv
+tr -f csv sbom components sbom.json -o packages.csv
 
 # Combine with other global options
-threat-radar -q -f json --no-color cve scan-image myapp:latest > results.json
+tr -q -f json --no-color cve scan-image myapp:latest > results.json
 ```
 
 **For complete CLI features documentation, see [docs/CLI_FEATURES.md](docs/CLI_FEATURES.md)**
@@ -374,37 +374,37 @@ grype version
 
 ```bash
 # Scan Docker image for CVEs
-threat-radar cve scan-image alpine:3.18
-threat-radar cve scan-image python:3.11 --severity HIGH
-threat-radar cve scan-image ubuntu:22.04 --only-fixed -o results.json
+tr cve scan-image alpine:3.18
+tr cve scan-image python:3.11 --severity HIGH
+tr cve scan-image ubuntu:22.04 --only-fixed -o results.json
 
 # Scan with automatic cleanup (removes image after scan if newly pulled)
-threat-radar cve scan-image nginx:latest --cleanup
-threat-radar cve scan-image test-app:v1.0 --cleanup --severity HIGH
+tr cve scan-image nginx:latest --cleanup
+tr cve scan-image test-app:v1.0 --cleanup --severity HIGH
 
 # Auto-save results to storage/cve_storage/ directory
-threat-radar cve scan-image alpine:3.18 --auto-save
-threat-radar cve scan-image myapp:latest --as  # Short form
-threat-radar cve scan-image python:3.11 --auto-save --cleanup  # Combined
+tr cve scan-image alpine:3.18 --auto-save
+tr cve scan-image myapp:latest --as  # Short form
+tr cve scan-image python:3.11 --auto-save --cleanup  # Combined
 
 # Scan pre-generated SBOM file (CI/CD friendly)
-threat-radar cve scan-sbom my-app-sbom.json
-threat-radar cve scan-sbom docker-sbom.json --severity CRITICAL
-threat-radar cve scan-sbom sbom.json --only-fixed -o cve-results.json
+tr cve scan-sbom my-app-sbom.json
+tr cve scan-sbom docker-sbom.json --severity CRITICAL
+tr cve scan-sbom sbom.json --only-fixed -o cve-results.json
 
 # SBOM scanning with cleanup and auto-save
-threat-radar cve scan-sbom alpine-sbom.json --cleanup --image alpine:3.18
-threat-radar cve scan-sbom app-sbom.json --auto-save  # Auto-save results
+tr cve scan-sbom alpine-sbom.json --cleanup --image alpine:3.18
+tr cve scan-sbom app-sbom.json --auto-save  # Auto-save results
 
 # Scan local directory for vulnerabilities
-threat-radar cve scan-directory ./my-app
-threat-radar cve scan-directory /path/to/project --severity MEDIUM
-threat-radar cve scan-directory . --only-fixed -o results.json
-threat-radar cve scan-directory ./src --auto-save  # Auto-save
+tr cve scan-directory ./my-app
+tr cve scan-directory /path/to/project --severity MEDIUM
+tr cve scan-directory . --only-fixed -o results.json
+tr cve scan-directory ./src --auto-save  # Auto-save
 
 # Vulnerability database management
-threat-radar cve db-update                     # Update Grype database
-threat-radar cve db-status                     # Show database status
+tr cve db-update                     # Update Grype database
+tr cve db-status                     # Show database status
 ```
 
 ### CVE Scanning Workflow
@@ -441,14 +441,14 @@ The `--cleanup` flag automatically removes Docker images after scanning to save 
 **Use cases:**
 ```bash
 # CI/CD pipelines - scan and cleanup
-threat-radar cve scan-image myapp:latest --cleanup --severity HIGH
+tr cve scan-image myapp:latest --cleanup --severity HIGH
 
 # Testing multiple images without storage buildup
-threat-radar cve scan-image nginx:alpine --cleanup
-threat-radar cve scan-image redis:alpine --cleanup
+tr cve scan-image nginx:alpine --cleanup
+tr cve scan-image redis:alpine --cleanup
 
 # SBOM scanning with source image cleanup
-threat-radar cve scan-sbom app-sbom.json --cleanup --image myapp:v1.0
+tr cve scan-sbom app-sbom.json --cleanup --image myapp:v1.0
 ```
 
 **Storage management:**
@@ -470,15 +470,15 @@ The `--auto-save` (or `--as`) flag automatically saves CVE scan results to the `
 **Use cases:**
 ```bash
 # Keep history of all scans in one place
-threat-radar cve scan-image myapp:v1.0 --auto-save
-threat-radar cve scan-image myapp:v1.1 --auto-save
-threat-radar cve scan-image myapp:v1.2 --auto-save
+tr cve scan-image myapp:v1.0 --auto-save
+tr cve scan-image myapp:v1.1 --auto-save
+tr cve scan-image myapp:v1.2 --auto-save
 
 # CI/CD: Auto-save + cleanup for ephemeral environments
-threat-radar cve scan-image $IMAGE --auto-save --cleanup --fail-on HIGH
+tr cve scan-image $IMAGE --auto-save --cleanup --fail-on HIGH
 
 # Save to both custom location and auto-save
-threat-radar cve scan-image alpine:3.18 -o report.json --auto-save
+tr cve scan-image alpine:3.18 -o report.json --auto-save
 ```
 
 **File naming examples:**
@@ -505,13 +505,13 @@ find storage/cve_storage/ -name "*.json" -mtime +30 -delete  # Remove >30 days o
 
 ```bash
 # Generate SBOM with Syft
-threat-radar sbom generate docker:alpine:3.18 -o sbom.json
+tr sbom generate docker:alpine:3.18 -o sbom.json
 
 # Scan SBOM with Grype for vulnerabilities
-threat-radar cve scan-sbom sbom.json --severity HIGH -o vulns.json
+tr cve scan-sbom sbom.json --severity HIGH -o vulns.json
 
 # Or scan Docker image directly (Grype handles SBOM internally)
-threat-radar cve scan-image alpine:3.18 --severity HIGH -o vulns.json
+tr cve scan-image alpine:3.18 --severity HIGH -o vulns.json
 ```
 
 ## AI Commands Reference
@@ -554,20 +554,20 @@ Analyze CVE scan results to understand exploitability and business impact:
 
 ```bash
 # Basic analysis (auto-batches for large scans)
-threat-radar ai analyze cve-results.json
+tr ai analyze cve-results.json
 
 # Specify AI provider and model
-threat-radar ai analyze results.json --provider openai --model gpt-4o
-threat-radar ai analyze results.json --provider anthropic --model claude-3-5-sonnet-20241022
+tr ai analyze results.json --provider openai --model gpt-4o
+tr ai analyze results.json --provider anthropic --model claude-3-5-sonnet-20241022
 
 # Save analysis to file
-threat-radar ai analyze scan.json -o analysis.json
+tr ai analyze scan.json -o analysis.json
 
 # Auto-save to storage/ai_analysis/
-threat-radar ai analyze results.json --auto-save
+tr ai analyze results.json --auto-save
 
 # Use local model (Ollama)
-threat-radar ai analyze scan.json --provider ollama --model llama2
+tr ai analyze scan.json --provider ollama --model llama2
 ```
 
 **BATCH PROCESSING FOR LARGE SCANS:**
@@ -576,16 +576,16 @@ Automatically handles 100+ CVE scans via intelligent batch processing:
 
 ```bash
 # Auto-batch mode (default) - automatically batches when >30 CVEs
-threat-radar ai analyze large-scan.json
+tr ai analyze large-scan.json
 
 # Force batch processing with custom size
-threat-radar ai analyze scan.json --batch-mode enabled --batch-size 30
+tr ai analyze scan.json --batch-mode enabled --batch-size 30
 
 # Disable batching (use single-pass, may fail for large scans)
-threat-radar ai analyze scan.json --batch-mode disabled
+tr ai analyze scan.json --batch-mode disabled
 
 # Hide progress bar (useful for CI/CD)
-threat-radar ai analyze scan.json --no-progress
+tr ai analyze scan.json --no-progress
 ```
 
 **How batch processing works:**
@@ -607,16 +607,16 @@ Reduce analysis time and cost by filtering to specific severity levels:
 
 ```bash
 # Analyze only CRITICAL vulnerabilities
-threat-radar ai analyze scan.json --severity critical
+tr ai analyze scan.json --severity critical
 
 # Analyze HIGH and above (critical + high)
-threat-radar ai analyze scan.json --severity high
+tr ai analyze scan.json --severity high
 
 # Analyze MEDIUM and above (critical + high + medium)
-threat-radar ai analyze scan.json --severity medium
+tr ai analyze scan.json --severity medium
 
 # Combine with batch processing
-threat-radar ai analyze large-scan.json --severity high --batch-size 20
+tr ai analyze large-scan.json --severity high --batch-size 20
 ```
 
 **Severity levels** (from highest to lowest):
@@ -644,16 +644,16 @@ Generate AI-powered prioritized vulnerability lists:
 
 ```bash
 # Generate priority list
-threat-radar ai prioritize cve-results.json
+tr ai prioritize cve-results.json
 
 # Show top 20 priorities
-threat-radar ai prioritize results.json --top 20
+tr ai prioritize results.json --top 20
 
 # Save prioritization
-threat-radar ai prioritize scan.json -o priorities.json
+tr ai prioritize scan.json -o priorities.json
 
 # Auto-save results
-threat-radar ai prioritize results.json --auto-save
+tr ai prioritize results.json --auto-save
 ```
 
 **Output includes:**
@@ -669,16 +669,16 @@ Create detailed, actionable remediation guidance:
 
 ```bash
 # Generate remediation plan
-threat-radar ai remediate cve-results.json
+tr ai remediate cve-results.json
 
 # Save plan to file
-threat-radar ai remediate scan.json -o remediation.json
+tr ai remediate scan.json -o remediation.json
 
 # Hide upgrade commands
-threat-radar ai remediate results.json --no-commands
+tr ai remediate results.json --no-commands
 
 # Use local model
-threat-radar ai remediate scan.json --provider ollama
+tr ai remediate scan.json --provider ollama
 ```
 
 **Output includes:**
@@ -697,25 +697,25 @@ threat-radar ai remediate scan.json --provider ollama
 
 ```bash
 # 1. Scan Docker image for vulnerabilities
-threat-radar cve scan-image alpine:3.18 --auto-save -o cve-scan.json
+tr cve scan-image alpine:3.18 --auto-save -o cve-scan.json
 
 # 2. Analyze with AI
-threat-radar ai analyze cve-scan.json --auto-save -o ai-analysis.json
+tr ai analyze cve-scan.json --auto-save -o ai-analysis.json
 
 # 3. Generate priorities
-threat-radar ai prioritize cve-scan.json --auto-save -o priorities.json
+tr ai prioritize cve-scan.json --auto-save -o priorities.json
 
 # 4. Create remediation plan
-threat-radar ai remediate cve-scan.json --auto-save -o remediation.json
+tr ai remediate cve-scan.json --auto-save -o remediation.json
 ```
 
 #### CI/CD Integration
 
 ```bash
 # Scan, analyze, and prioritize in one pipeline
-threat-radar cve scan-image $IMAGE --auto-save --cleanup > scan.json
-threat-radar ai analyze scan.json --auto-save
-threat-radar ai prioritize scan.json --top 10 --auto-save
+tr cve scan-image $IMAGE --auto-save --cleanup > scan.json
+tr ai analyze scan.json --auto-save
+tr ai prioritize scan.json --top 10 --auto-save
 ```
 
 #### Using Local Models (Privacy-Focused)
@@ -729,9 +729,9 @@ threat-radar ai prioritize scan.json --top 10 --auto-save
 export AI_PROVIDER=ollama
 export AI_MODEL=llama2
 
-threat-radar ai analyze cve-scan.json
-threat-radar ai prioritize cve-scan.json
-threat-radar ai remediate cve-scan.json
+tr ai analyze cve-scan.json
+tr ai prioritize cve-scan.json
+tr ai remediate cve-scan.json
 ```
 
 ### AI Storage Management
@@ -826,9 +826,9 @@ export AI_PROVIDER=anthropic
 export AI_MODEL=claude-3-5-sonnet-20241022
 
 # Use with any AI command
-threat-radar ai analyze scan.json --provider anthropic
-threat-radar ai prioritize scan.json --provider anthropic
-threat-radar ai remediate scan.json --provider anthropic
+tr ai analyze scan.json --provider anthropic
+tr ai prioritize scan.json --provider anthropic
+tr ai remediate scan.json --provider anthropic
 ```
 
 **Available Claude Models:**
@@ -850,9 +850,9 @@ export AI_PROVIDER=openrouter
 export AI_MODEL=anthropic/claude-3.5-sonnet
 
 # Use with any AI command
-threat-radar ai analyze scan.json --provider openrouter
-threat-radar ai prioritize scan.json --provider openrouter --model openai/gpt-4o
-threat-radar ai remediate scan.json --provider openrouter --model google/gemini-pro
+tr ai analyze scan.json --provider openrouter
+tr ai prioritize scan.json --provider openrouter --model openai/gpt-4o
+tr ai remediate scan.json --provider openrouter --model google/gemini-pro
 ```
 
 **Popular OpenRouter Models:**
@@ -874,19 +874,19 @@ threat-radar ai remediate scan.json --provider openrouter --model google/gemini-
 **Example Multi-Model Workflow:**
 ```bash
 # Use Claude for detailed analysis (best reasoning)
-threat-radar ai analyze scan.json \
+tr ai analyze scan.json \
   --provider openrouter \
   --model anthropic/claude-3.5-sonnet \
   --auto-save
 
 # Use GPT-4o for prioritization (fast structured output)
-threat-radar ai prioritize scan.json \
+tr ai prioritize scan.json \
   --provider openrouter \
   --model openai/gpt-4o \
   --auto-save
 
 # Use Gemini for cost-effective remediation
-threat-radar ai remediate scan.json \
+tr ai remediate scan.json \
   --provider openrouter \
   --model google/gemini-pro \
   --auto-save
@@ -916,62 +916,62 @@ export AI_MODEL=llama2
 ### Generation
 ```bash
 # Generate SBOM from local directory
-threat-radar sbom generate ./path/to/project -f cyclonedx-json
+tr sbom generate ./path/to/project -f cyclonedx-json
 
 # Generate SBOM from Docker image
-threat-radar sbom docker alpine:3.18 -o sbom.json
+tr sbom docker alpine:3.18 -o sbom.json
 
 # Auto-save to sbom_storage/
-threat-radar sbom generate . --auto-save
-threat-radar sbom docker python:3.11 --auto-save
+tr sbom generate . --auto-save
+tr sbom docker python:3.11 --auto-save
 ```
 
 ### Analysis
 ```bash
 # Read and display SBOM
-threat-radar sbom read sbom.json
-threat-radar sbom read sbom.json --format json
+tr sbom read sbom.json
+tr sbom read sbom.json --format json
 
 # Get statistics
-threat-radar sbom stats sbom.json
+tr sbom stats sbom.json
 
 # Search for packages
-threat-radar sbom search sbom.json openssl
+tr sbom search sbom.json openssl
 
 # List components with filtering
-threat-radar sbom components sbom.json --type library
-threat-radar sbom components sbom.json --language python
-threat-radar sbom components sbom.json --group-by type
+tr sbom components sbom.json --type library
+tr sbom components sbom.json --language python
+tr sbom components sbom.json --group-by type
 ```
 
 ### Comparison
 ```bash
 # Compare two SBOMs (useful for tracking changes)
-threat-radar sbom compare alpine-3.17-sbom.json alpine-3.18-sbom.json
-threat-radar sbom compare old.json new.json --versions
+tr sbom compare alpine-3.17-sbom.json alpine-3.18-sbom.json
+tr sbom compare old.json new.json --versions
 ```
 
 ### Export
 ```bash
 # Export to CSV
-threat-radar sbom export sbom.json -o packages.csv -f csv
+tr sbom export sbom.json -o packages.csv -f csv
 
 # Export as requirements.txt (Python packages)
-threat-radar sbom export sbom.json -o requirements.txt -f requirements
+tr sbom export sbom.json -o requirements.txt -f requirements
 ```
 
 ### Storage Management
 ```bash
 # List all stored SBOMs
-threat-radar sbom list
+tr sbom list
 
 # List by category
-threat-radar sbom list --category docker
-threat-radar sbom list --category local
-threat-radar sbom list --category comparisons
+tr sbom list --category docker
+tr sbom list --category local
+tr sbom list --category comparisons
 
 # Limit results
-threat-radar sbom list --limit 10
+tr sbom list --limit 10
 ```
 
 ## Comprehensive Reporting Commands
@@ -1001,16 +1001,16 @@ The reporting system provides AI-powered vulnerability reports with multiple out
 IMAGE="myapp:latest"
 
 # 1. Scan image
-threat-radar cve scan-image $IMAGE --auto-save -o scan.json
+tr cve scan-image $IMAGE --auto-save -o scan.json
 
 # 2. Build graph and find attack paths
-threat-radar graph build scan.json -o graph.graphml
-threat-radar graph attack-paths graph.graphml -o attack-paths.json
+tr graph build scan.json -o graph.graphml
+tr graph attack-paths graph.graphml -o attack-paths.json
 
 # 3. Generate reports in all formats with attack paths
-threat-radar report generate scan.json -o report.html --attack-paths attack-paths.json
-threat-radar report generate scan.json -o report.pdf --attack-paths attack-paths.json
-threat-radar report generate scan.json -o report.md --attack-paths attack-paths.json
+tr report generate scan.json -o report.html --attack-paths attack-paths.json
+tr report generate scan.json -o report.pdf --attack-paths attack-paths.json
+tr report generate scan.json -o report.md --attack-paths attack-paths.json
 
 # Result: 3 comprehensive reports (HTML, PDF, Markdown) with:
 # - Vulnerability analysis
@@ -1023,42 +1023,42 @@ threat-radar report generate scan.json -o report.md --attack-paths attack-paths.
 
 ```bash
 # Generate comprehensive HTML report with AI executive summary
-threat-radar report generate scan-results.json -o report.html -f html
+tr report generate scan-results.json -o report.html -f html
 
 # Executive summary in Markdown (for documentation)
-threat-radar report generate scan-results.json -o summary.md -f markdown --level executive
+tr report generate scan-results.json -o summary.md -f markdown --level executive
 
 # Executive PDF report (NEW!)
-threat-radar report generate scan-results.json -o executive.pdf -f pdf --level executive
+tr report generate scan-results.json -o executive.pdf -f pdf --level executive
 
 # Detailed JSON report with dashboard data
-threat-radar report generate scan-results.json -o detailed.json --level detailed
+tr report generate scan-results.json -o detailed.json --level detailed
 
 # Critical-only issues (for immediate action)
-threat-radar report generate scan-results.json -o critical.json --level critical-only
+tr report generate scan-results.json -o critical.json --level critical-only
 
 # Use custom AI model
-threat-radar report generate scan-results.json --ai-provider ollama --ai-model llama2
+tr report generate scan-results.json --ai-provider ollama --ai-model llama2
 
 # Without AI executive summary (faster)
-threat-radar report generate scan-results.json -o report.json --no-executive
+tr report generate scan-results.json -o report.json --no-executive
 ```
 
 #### Reports with Attack Path Analysis (NEW!)
 
 ```bash
 # Generate attack paths first
-threat-radar graph build scan.json -o graph.graphml
-threat-radar graph attack-paths graph.graphml -o attack-paths.json
+tr graph build scan.json -o graph.graphml
+tr graph attack-paths graph.graphml -o attack-paths.json
 
 # HTML report with integrated attack paths
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o comprehensive-report.html \
   -f html \
   --attack-paths attack-paths.json
 
 # PDF executive report with attack path analysis
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o executive-with-paths.pdf \
   -f pdf \
   --level executive \
@@ -1066,7 +1066,7 @@ threat-radar report generate scan.json \
   --ai-provider openai
 
 # Markdown documentation with attack paths
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o security-analysis.md \
   -f markdown \
   --level detailed \
@@ -1104,7 +1104,7 @@ threat-radar report generate scan.json \
 
 #### JSON Format
 ```bash
-threat-radar report generate scan.json -o report.json -f json
+tr report generate scan.json -o report.json -f json
 ```
 - Machine-readable structured data
 - Suitable for API integrations
@@ -1113,7 +1113,7 @@ threat-radar report generate scan.json -o report.json -f json
 
 #### Markdown Format
 ```bash
-threat-radar report generate scan.json -o report.md -f markdown
+tr report generate scan.json -o report.md -f markdown
 ```
 - Human-readable documentation
 - Great for GitHub/GitLab issues
@@ -1122,7 +1122,7 @@ threat-radar report generate scan.json -o report.md -f markdown
 
 #### HTML Format
 ```bash
-threat-radar report generate scan.json -o report.html -f html
+tr report generate scan.json -o report.html -f html
 ```
 - Beautiful web-based reports
 - Styled with modern CSS
@@ -1136,7 +1136,7 @@ Export visualization-ready data for custom dashboards (Grafana, custom web apps,
 
 ```bash
 # Export dashboard data structure
-threat-radar report dashboard-export scan-results.json -o dashboard.json
+tr report dashboard-export scan-results.json -o dashboard.json
 ```
 
 **Dashboard data includes:**
@@ -1172,18 +1172,18 @@ Example dashboard.json structure:
 
 ```bash
 # Generate report with integrated attack path analysis
-threat-radar cve scan-image myapp:production --auto-save -o scan.json
-threat-radar graph build scan.json --auto-save -o vuln-graph.graphml
-threat-radar graph attack-paths vuln-graph.graphml --max-paths 20 -o attack-paths.json
+tr cve scan-image myapp:production --auto-save -o scan.json
+tr graph build scan.json --auto-save -o vuln-graph.graphml
+tr graph attack-paths vuln-graph.graphml --max-paths 20 -o attack-paths.json
 
 # Single command to generate comprehensive report with attack paths
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o comprehensive-report.html \
   -f html \
   --attack-paths attack-paths.json
 
 # Or with PDF export
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o executive-report.pdf \
   -f pdf \
   --level executive \
@@ -1221,32 +1221,32 @@ echo "Generating attack path-aware security report for $TARGET..."
 
 # Step 1: Scan for vulnerabilities
 echo "1. Scanning for vulnerabilities..."
-threat-radar cve scan-image $TARGET --auto-save -o scan.json
+tr cve scan-image $TARGET --auto-save -o scan.json
 
 # Step 2: Build environment graph with vulnerabilities
 echo "2. Building infrastructure graph..."
-threat-radar env build-graph production-env.json \
+tr env build-graph production-env.json \
   --merge-scan scan.json \
   --auto-save -o env-graph.graphml
 
 # Step 3: Analyze attack surface
 echo "3. Analyzing attack surface..."
-threat-radar graph attack-surface env-graph.graphml \
+tr graph attack-surface env-graph.graphml \
   -o attack-surface.json
 
 # Step 4: Find specific attack paths
 echo "4. Discovering attack paths..."
-threat-radar graph attack-paths env-graph.graphml \
+tr graph attack-paths env-graph.graphml \
   --max-paths 50 -o attack-paths.json
 
 # Step 5: Identify privilege escalation opportunities
 echo "5. Detecting privilege escalation vectors..."
-threat-radar graph privilege-escalation env-graph.graphml \
+tr graph privilege-escalation env-graph.graphml \
   -o privesc.json
 
 # Step 6: Generate integrated technical report with attack paths (HTML)
 echo "6. Generating technical security report with attack paths..."
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o reports/technical-report.html \
   -f html \
   --level detailed \
@@ -1254,7 +1254,7 @@ threat-radar report generate scan.json \
 
 # Step 7: Generate executive PDF report with risk context and attack paths
 echo "7. Generating executive PDF summary..."
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o reports/executive-summary.pdf \
   -f pdf \
   --level executive \
@@ -1263,7 +1263,7 @@ threat-radar report generate scan.json \
 
 # Step 8: Generate Markdown report for documentation
 echo "8. Generating Markdown report..."
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o reports/security-analysis.md \
   -f markdown \
   --level detailed \
@@ -1271,18 +1271,18 @@ threat-radar report generate scan.json \
 
 # Step 9: Create attack path visualizations
 echo "9. Creating visualizations..."
-threat-radar visualize attack-paths env-graph.graphml \
+tr visualize attack-paths env-graph.graphml \
   -o reports/attack-paths-viz.html \
   --paths attack-paths.json \
   --max-paths 10
 
-threat-radar visualize topology env-graph.graphml \
+tr visualize topology env-graph.graphml \
   -o reports/topology-security.html \
   --view zones
 
 # Step 10: Export dashboard data
 echo "10. Exporting dashboard metrics..."
-threat-radar report dashboard-export scan.json \
+tr report dashboard-export scan.json \
   -o reports/dashboard-data.json
 
 echo "✅ Complete attack-path-aware report generated!"
@@ -1311,25 +1311,25 @@ Threat Radar provides flexible report customization through report levels and AI
 
 ```bash
 # Executive level - For C-suite and business stakeholders
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o exec-report.md \
   -f markdown \
   --level executive \
   --ai-provider openai
 
 # Summary level - For security team quick reviews
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o summary-report.json \
   --level summary
 
 # Detailed level - For technical analysis and remediation planning
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o detailed-report.html \
   -f html \
   --level detailed
 
 # Critical-only - For incident response and urgent action
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o critical-report.json \
   --level critical-only
 ```
@@ -1338,22 +1338,22 @@ threat-radar report generate scan.json \
 
 ```bash
 # Use OpenAI for executive summaries
-threat-radar report generate scan.json \
+tr report generate scan.json \
   --ai-provider openai \
   --ai-model gpt-4o
 
 # Use Anthropic Claude for deeper analysis
-threat-radar report generate scan.json \
+tr report generate scan.json \
   --ai-provider anthropic \
   --ai-model claude-3-5-sonnet-20241022
 
 # Use local Ollama for privacy
-threat-radar report generate scan.json \
+tr report generate scan.json \
   --ai-provider ollama \
   --ai-model llama2
 
 # Disable AI for faster generation
-threat-radar report generate scan.json \
+tr report generate scan.json \
   --no-executive
 ```
 
@@ -1361,11 +1361,11 @@ threat-radar report generate scan.json \
 
 ```bash
 # Include/exclude dashboard data
-threat-radar report generate scan.json --dashboard  # Include (default)
-threat-radar report generate scan.json --no-dashboard  # Exclude
+tr report generate scan.json --dashboard  # Include (default)
+tr report generate scan.json --no-dashboard  # Exclude
 
 # Export custom dashboard metrics only
-threat-radar report dashboard-export scan.json -o custom-dashboard.json
+tr report dashboard-export scan.json -o custom-dashboard.json
 ```
 
 **Format-Specific Customization:**
@@ -1387,9 +1387,9 @@ Automate security reporting with cron jobs, CI/CD pipelines, and custom workflow
 # Add to crontab: crontab -e
 
 # Daily vulnerability scan and report (2 AM)
-0 2 * * * /usr/local/bin/threat-radar cve scan-image myapp:latest \
+0 2 * * * /usr/local/bin/tr cve scan-image myapp:latest \
   --auto-save && \
-  /usr/local/bin/threat-radar report generate \
+  /usr/local/bin/tr report generate \
   storage/cve_storage/myapp_latest_image_*.json \
   -o /var/reports/daily-$(date +\%Y\%m\%d).html \
   -f html --level summary
@@ -1401,9 +1401,9 @@ Automate security reporting with cron jobs, CI/CD pipelines, and custom workflow
 0 8 1 * * /home/user/scripts/monthly-compliance.sh
 
 # Hourly critical-only scan for production (business hours)
-0 9-17 * * 1-5 /usr/local/bin/threat-radar cve scan-image prod:latest \
+0 9-17 * * 1-5 /usr/local/bin/tr cve scan-image prod:latest \
   --auto-save && \
-  /usr/local/bin/threat-radar report generate \
+  /usr/local/bin/tr report generate \
   storage/cve_storage/prod_latest_*.json \
   --level critical-only \
   -o /var/reports/critical-$(date +\%Y\%m\%d-\%H\%M).json
@@ -1431,7 +1431,7 @@ jobs:
       - name: Scan all production images
         run: |
           for image in frontend:prod backend:prod api:prod; do
-            threat-radar cve scan-image $image \
+            tr cve scan-image $image \
               --auto-save -o scan-${image/:/-}.json
           done
 
@@ -1439,7 +1439,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          threat-radar report generate scan-*.json \
+          tr report generate scan-*.json \
             -o weekly-report.html \
             -f html \
             --level detailed \
@@ -1449,7 +1449,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          threat-radar report generate scan-*.json \
+          tr report generate scan-*.json \
             -o executive-summary.md \
             -f markdown \
             --level executive \
@@ -1457,7 +1457,7 @@ jobs:
 
       - name: Export dashboard data
         run: |
-          threat-radar report dashboard-export scan-*.json \
+          tr report dashboard-export scan-*.json \
             -o dashboard-metrics.json
 
       - name: Upload reports to S3
@@ -1517,7 +1517,7 @@ pipeline {
 
                     images.each { image ->
                         sh """
-                            threat-radar cve scan-image ${image} \
+                            tr cve scan-image ${image} \
                                 --auto-save \
                                 -o scan-${image.replaceAll(':', '-')}.json
                         """
@@ -1531,7 +1531,7 @@ pipeline {
                 stage('Technical Report') {
                     steps {
                         sh '''
-                            threat-radar report generate scan-*.json \
+                            tr report generate scan-*.json \
                                 -o technical-report.html \
                                 -f html \
                                 --level detailed
@@ -1542,7 +1542,7 @@ pipeline {
                 stage('Executive Report') {
                     steps {
                         sh '''
-                            threat-radar report generate scan-*.json \
+                            tr report generate scan-*.json \
                                 -o executive-report.md \
                                 -f markdown \
                                 --level executive \
@@ -1554,7 +1554,7 @@ pipeline {
                 stage('Dashboard Export') {
                     steps {
                         sh '''
-                            threat-radar report dashboard-export scan-*.json \
+                            tr report dashboard-export scan-*.json \
                                 -o dashboard-data.json
                         '''
                     }
@@ -1745,10 +1745,10 @@ Track vulnerability changes over time:
 
 ```bash
 # Compare two scan results
-threat-radar report compare old-scan.json new-scan.json
+tr report compare old-scan.json new-scan.json
 
 # Save comparison report
-threat-radar report compare baseline.json current.json -o comparison.json
+tr report compare baseline.json current.json -o comparison.json
 ```
 
 **Comparison shows:**
@@ -1770,17 +1770,17 @@ WEEK=$(date +%Y-W%U)
 IMAGE="myapp:production"
 
 # 1. Scan production Docker image
-threat-radar cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
+tr cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
 
 # 2. Build vulnerability graph
-threat-radar graph build scan-${WEEK}.json --auto-save -o graph-${WEEK}.graphml
+tr graph build scan-${WEEK}.json --auto-save -o graph-${WEEK}.graphml
 
 # 3. Discover attack paths
-threat-radar graph attack-paths graph-${WEEK}.graphml \
+tr graph attack-paths graph-${WEEK}.graphml \
   --max-paths 30 -o attack-paths-${WEEK}.json
 
 # 4. Generate comprehensive HTML report for security team with attack paths
-threat-radar report generate scan-${WEEK}.json \
+tr report generate scan-${WEEK}.json \
   -o reports/detailed-${WEEK}.html \
   -f html \
   --level detailed \
@@ -1788,7 +1788,7 @@ threat-radar report generate scan-${WEEK}.json \
   --ai-provider openai
 
 # 5. Generate executive PDF summary for leadership meeting
-threat-radar report generate scan-${WEEK}.json \
+tr report generate scan-${WEEK}.json \
   -o reports/exec-${WEEK}.pdf \
   -f pdf \
   --level executive \
@@ -1796,12 +1796,12 @@ threat-radar report generate scan-${WEEK}.json \
   --ai-provider openai
 
 # 6. Export dashboard data for Grafana monitoring
-threat-radar report dashboard-export scan-${WEEK}.json \
+tr report dashboard-export scan-${WEEK}.json \
   -o dashboards/metrics-${WEEK}.json
 
 # 7. Compare with last week's scan
 if [ -f "scan-${LAST_WEEK}.json" ]; then
-  threat-radar report compare \
+  tr report compare \
     scan-${LAST_WEEK}.json \
     scan-${WEEK}.json \
     -o reports/trend-${WEEK}.json
@@ -1847,14 +1847,14 @@ jobs:
 
       - name: Scan for vulnerabilities
         run: |
-          threat-radar cve scan-image app:${{ github.sha }} \
+          tr cve scan-image app:${{ github.sha }} \
             -o scan-results.json \
             --auto-save \
             --cleanup
 
       - name: Generate critical-only report
         run: |
-          threat-radar report generate scan-results.json \
+          tr report generate scan-results.json \
             -o critical-report.json \
             --level critical-only
 
@@ -1874,18 +1874,18 @@ jobs:
 
       - name: Build vulnerability graph
         run: |
-          threat-radar graph build scan-results.json \
+          tr graph build scan-results.json \
             --auto-save -o vuln-graph.graphml
 
       - name: Discover attack paths
         run: |
-          threat-radar graph attack-paths vuln-graph.graphml \
+          tr graph attack-paths vuln-graph.graphml \
             --max-paths 20 -o attack-paths.json
 
       - name: Generate PR comment report with attack paths
         if: github.event_name == 'pull_request'
         run: |
-          threat-radar report generate scan-results.json \
+          tr report generate scan-results.json \
             -o pr-report.md \
             -f markdown \
             --level summary \
@@ -1899,7 +1899,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          threat-radar report generate scan-results.json \
+          tr report generate scan-results.json \
             -o executive-report.pdf \
             -f pdf \
             --level executive \
@@ -1941,19 +1941,19 @@ for IMAGE in "${IMAGES[@]}"; do
   SAFE_NAME="${IMAGE//:/─}"
 
   # Scan for vulnerabilities
-  threat-radar cve scan-image $IMAGE \
+  tr cve scan-image $IMAGE \
     -o "compliance/${SAFE_NAME}-${QUARTER}.json" \
     --auto-save
 
   # Build graph and find attack paths
-  threat-radar graph build "compliance/${SAFE_NAME}-${QUARTER}.json" \
+  tr graph build "compliance/${SAFE_NAME}-${QUARTER}.json" \
     -o "compliance/${SAFE_NAME}-graph.graphml"
 
-  threat-radar graph attack-paths "compliance/${SAFE_NAME}-graph.graphml" \
+  tr graph attack-paths "compliance/${SAFE_NAME}-graph.graphml" \
     --max-paths 30 -o "compliance/${SAFE_NAME}-paths.json"
 
   # Generate detailed HTML report with attack paths
-  threat-radar report generate \
+  tr report generate \
     "compliance/${SAFE_NAME}-${QUARTER}.json" \
     -o "compliance/${SAFE_NAME}-${QUARTER}.html" \
     -f html \
@@ -1962,7 +1962,7 @@ for IMAGE in "${IMAGES[@]}"; do
     --ai-provider openai
 
   # Generate executive PDF for auditors
-  threat-radar report generate \
+  tr report generate \
     "compliance/${SAFE_NAME}-${QUARTER}.json" \
     -o "compliance/${SAFE_NAME}-${QUARTER}.pdf" \
     -f pdf \
@@ -2121,21 +2121,21 @@ Threat Radar supports multiple export formats for reports and visualizations:
 
 ```bash
 # Export as JSON (default) - Best for automation
-threat-radar report generate scan.json -o report.json -f json
+tr report generate scan.json -o report.json -f json
 
 # Export as Markdown - Best for documentation
-threat-radar report generate scan.json -o report.md -f markdown
+tr report generate scan.json -o report.md -f markdown
 
 # Export as HTML - Best for presentations
-threat-radar report generate scan.json -o report.html -f html
+tr report generate scan.json -o report.html -f html
 
 # Export as PDF - Best for executives and printing
-threat-radar report generate scan.json -o report.pdf -f pdf
+tr report generate scan.json -o report.pdf -f pdf
 
 # Auto-detect format from file extension
-threat-radar report generate scan.json -o report.html  # Automatically uses HTML
-threat-radar report generate scan.json -o report.md    # Automatically uses Markdown
-threat-radar report generate scan.json -o report.pdf   # Automatically uses PDF
+tr report generate scan.json -o report.html  # Automatically uses HTML
+tr report generate scan.json -o report.md    # Automatically uses Markdown
+tr report generate scan.json -o report.pdf   # Automatically uses PDF
 ```
 
 **Note:** PDF export requires weasyprint:
@@ -2143,7 +2143,7 @@ threat-radar report generate scan.json -o report.pdf   # Automatically uses PDF
 # Install weasyprint for PDF export
 pip install weasyprint
 
-# Or install threat-radar with PDF support
+# Or install tr with PDF support
 pip install threat-radar[pdf]
 ```
 
@@ -2153,7 +2153,7 @@ Dashboard data is exported in JSON format optimized for visualization tools:
 
 ```bash
 # Export dashboard data for Grafana
-threat-radar report dashboard-export scan.json -o dashboard.json
+tr report dashboard-export scan.json -o dashboard.json
 
 # Dashboard data structure includes:
 # - Summary cards (total vulnerabilities, critical count, CVSS scores)
@@ -2168,14 +2168,14 @@ threat-radar report dashboard-export scan.json -o dashboard.json
 
 ```bash
 # Export for Grafana dashboard
-threat-radar report dashboard-export scan.json -o /var/grafana/data/security-metrics.json
+tr report dashboard-export scan.json -o /var/grafana/data/security-metrics.json
 
 # Export for custom web dashboard
-threat-radar report dashboard-export scan.json | \
+tr report dashboard-export scan.json | \
   curl -X POST https://dashboard.company.com/api/metrics -d @-
 
 # Export for Splunk/ELK
-threat-radar report generate scan.json -f json | \
+tr report generate scan.json -f json | \
   curl -X POST https://splunk.company.com:8088/services/collector -d @-
 ```
 
@@ -2196,16 +2196,16 @@ Graph visualizations support multiple export formats via the `visualize export` 
 
 ```bash
 # Export graph visualization as HTML
-threat-radar visualize export graph.graphml -o viz.html --format html
+tr visualize export graph.graphml -o viz.html --format html
 
 # Export as high-resolution PNG
-threat-radar visualize export graph.graphml -o viz.png --format png
+tr visualize export graph.graphml -o viz.png --format png
 
 # Export as PDF for reports
-threat-radar visualize export graph.graphml -o viz.pdf --format pdf
+tr visualize export graph.graphml -o viz.pdf --format pdf
 
 # Export multiple formats at once
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format html --format png --format pdf
 ```
 
@@ -2225,28 +2225,28 @@ echo "Generating complete security report suite for $TARGET..."
 
 # 1. Scan for vulnerabilities
 echo "Step 1: Scanning for vulnerabilities..."
-threat-radar cve scan-image $TARGET --auto-save -o scan.json
+tr cve scan-image $TARGET --auto-save -o scan.json
 
 # 2. Build graph and analyze attack paths
 echo "Step 2: Building vulnerability graph..."
-threat-radar graph build scan.json --auto-save -o graph.graphml
+tr graph build scan.json --auto-save -o graph.graphml
 
 echo "Step 3: Discovering attack paths..."
-threat-radar graph attack-paths graph.graphml \
+tr graph attack-paths graph.graphml \
   --max-paths 30 -o attack-paths.json
 
 # 3. Export reports in all formats with attack paths
 echo "Step 4: Generating reports in all formats..."
 
 # JSON - For automation
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o $REPORT_DIR/detailed-report.json \
   -f json \
   --level detailed \
   --attack-paths attack-paths.json
 
 # Markdown - For documentation
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o $REPORT_DIR/executive-summary.md \
   -f markdown \
   --level executive \
@@ -2254,14 +2254,14 @@ threat-radar report generate scan.json \
   --ai-provider openai
 
 # HTML - For presentations
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o $REPORT_DIR/technical-report.html \
   -f html \
   --level detailed \
   --attack-paths attack-paths.json
 
 # PDF - For executives and printing
-threat-radar report generate scan.json \
+tr report generate scan.json \
   -o $REPORT_DIR/executive-report.pdf \
   -f pdf \
   --level executive \
@@ -2270,16 +2270,16 @@ threat-radar report generate scan.json \
 
 # 4. Export dashboard data
 echo "Step 5: Exporting dashboard data..."
-threat-radar report dashboard-export scan.json \
+tr report dashboard-export scan.json \
   -o $REPORT_DIR/dashboard-data.json
 
 # 5. Export visualizations
 echo "Step 6: Creating visualizations..."
-threat-radar visualize export graph.graphml \
+tr visualize export graph.graphml \
   -o $REPORT_DIR/graph-viz \
   --format html --format png --format pdf
 
-threat-radar visualize attack-paths graph.graphml \
+tr visualize attack-paths graph.graphml \
   -o $REPORT_DIR/attack-paths-viz.html \
   --paths attack-paths.json
 
@@ -2306,15 +2306,15 @@ echo "Archive: security-report-${DATE}.tar.gz"
 
 ```bash
 # Upload to AWS S3
-threat-radar report generate scan.json -o report.html -f html
+tr report generate scan.json -o report.html -f html
 aws s3 cp report.html s3://security-reports/$(date +%Y/%m/%d)/
 
 # Upload to Google Cloud Storage
-threat-radar report generate scan.json -o report.json -f json
+tr report generate scan.json -o report.json -f json
 gsutil cp report.json gs://security-reports/$(date +%Y/%m/%d)/
 
 # Upload to Azure Blob Storage
-threat-radar report generate scan.json -o report.md -f markdown
+tr report generate scan.json -o report.md -f markdown
 az storage blob upload \
   --container-name security-reports \
   --name $(date +%Y/%m/%d)/report.md \
@@ -2447,19 +2447,19 @@ if __name__ == "__main__":
 
 ```bash
 # Import and analyze an image
-threat-radar docker import-image alpine:3.18 -o analysis.json
+tr docker import-image alpine:3.18 -o analysis.json
 
 # Scan existing local image
-threat-radar docker scan ubuntu:22.04
+tr docker scan ubuntu:22.04
 
 # List all local Docker images
-threat-radar docker list-images
+tr docker list-images
 
 # List packages in an image
-threat-radar docker packages alpine:3.18 --limit 20 --filter openssl
+tr docker packages alpine:3.18 --limit 20 --filter openssl
 
 # Generate Python SBOM
-threat-radar docker python-sbom python:3.11 -o sbom.json --format cyclonedx
+tr docker python-sbom python:3.11 -o sbom.json --format cyclonedx
 ```
 
 ## Graph Commands Reference
@@ -2479,49 +2479,49 @@ The graph database integration provides relationship-based vulnerability analysi
 
 ```bash
 # Build graph from CVE scan results
-threat-radar graph build scan-results.json -o vulnerability-graph.graphml
+tr graph build scan-results.json -o vulnerability-graph.graphml
 
 # Auto-save to storage/graph_storage/
-threat-radar graph build scan-results.json --auto-save
+tr graph build scan-results.json --auto-save
 
 # Example workflow: Scan and build graph
-threat-radar cve scan-image alpine:3.18 --auto-save -o scan.json
-threat-radar graph build scan.json --auto-save
+tr cve scan-image alpine:3.18 --auto-save -o scan.json
+tr graph build scan.json --auto-save
 ```
 
 ### Graph Querying
 
 ```bash
 # Find containers affected by a CVE (blast radius)
-threat-radar graph query graph.graphml --cve CVE-2023-1234
+tr graph query graph.graphml --cve CVE-2023-1234
 
 # Show top 10 most vulnerable packages
-threat-radar graph query graph.graphml --top-packages 10
+tr graph query graph.graphml --top-packages 10
 
 # Display vulnerability statistics
-threat-radar graph query graph.graphml --stats
+tr graph query graph.graphml --stats
 
 # Combined query
-threat-radar graph query graph.graphml --cve CVE-2023-1234 --stats
+tr graph query graph.graphml --cve CVE-2023-1234 --stats
 ```
 
 ### Graph Management
 
 ```bash
 # List all stored graphs
-threat-radar graph list
-threat-radar graph list --limit 10
+tr graph list
+tr graph list --limit 10
 
 # Show detailed graph information
-threat-radar graph info graph.graphml
+tr graph info graph.graphml
 
 # Find vulnerabilities with available fixes
-threat-radar graph fixes graph.graphml
-threat-radar graph fixes graph.graphml --severity critical
+tr graph fixes graph.graphml
+tr graph fixes graph.graphml --severity critical
 
 # Clean up old graphs
-threat-radar graph cleanup --days 30
-threat-radar graph cleanup --days 30 --force
+tr graph cleanup --days 30
+tr graph cleanup --days 30 --force
 ```
 
 ### Graph Architecture
@@ -2563,24 +2563,24 @@ du -sh storage/graph_storage/
 
 ```bash
 # 1. Scan multiple images
-threat-radar cve scan-image alpine:3.18 --auto-save -o alpine-scan.json
-threat-radar cve scan-image python:3.11 --auto-save -o python-scan.json
-threat-radar cve scan-image nginx:alpine --auto-save -o nginx-scan.json
+tr cve scan-image alpine:3.18 --auto-save -o alpine-scan.json
+tr cve scan-image python:3.11 --auto-save -o python-scan.json
+tr cve scan-image nginx:alpine --auto-save -o nginx-scan.json
 
 # 2. Build graphs
-threat-radar graph build alpine-scan.json --auto-save
-threat-radar graph build python-scan.json --auto-save
-threat-radar graph build nginx-scan.json --auto-save
+tr graph build alpine-scan.json --auto-save
+tr graph build python-scan.json --auto-save
+tr graph build nginx-scan.json --auto-save
 
 # 3. Analyze vulnerability landscape
-threat-radar graph list
-threat-radar graph query latest-graph.graphml --stats
+tr graph list
+tr graph query latest-graph.graphml --stats
 
 # 4. Find critical CVE impact
-threat-radar graph query latest-graph.graphml --cve CVE-2023-XXXX
+tr graph query latest-graph.graphml --cve CVE-2023-XXXX
 
 # 5. Identify fix candidates
-threat-radar graph fixes latest-graph.graphml --severity critical
+tr graph fixes latest-graph.graphml --severity critical
 
 # 6. Export for custom dashboards
 # Graphs are in GraphML format, compatible with:
@@ -2623,9 +2623,9 @@ storage.save_graph(client, "my-analysis")
 **1. Vulnerability Trend Analysis**
 ```bash
 # Build graphs over time
-threat-radar graph build scan-week1.json -o week1.graphml
-threat-radar graph build scan-week2.json -o week2.graphml
-threat-radar graph build scan-week3.json -o week3.graphml
+tr graph build scan-week1.json -o week1.graphml
+tr graph build scan-week2.json -o week2.graphml
+tr graph build scan-week3.json -o week3.graphml
 
 # Compare graphs programmatically to track improvements
 ```
@@ -2634,8 +2634,8 @@ threat-radar graph build scan-week3.json -o week3.graphml
 ```bash
 # Scan entire stack
 for image in frontend:latest backend:latest api:latest; do
-  threat-radar cve scan-image $image --auto-save -o ${image//:/─}-scan.json
-  threat-radar graph build ${image//:/─}-scan.json --auto-save
+  tr cve scan-image $image --auto-save -o ${image//:/─}-scan.json
+  tr graph build ${image//:/─}-scan.json --auto-save
 done
 
 # Analyze shared vulnerabilities across containers
@@ -2644,9 +2644,9 @@ done
 **3. CI/CD Integration**
 ```bash
 # Pipeline: Fail if critical vulnerabilities found
-threat-radar cve scan-image $IMAGE --auto-save -o scan.json
-threat-radar graph build scan.json -o graph.graphml
-threat-radar graph fixes graph.graphml --severity critical > critical-fixes.txt
+tr cve scan-image $IMAGE --auto-save -o scan.json
+tr graph build scan.json -o graph.graphml
+tr graph fixes graph.graphml --severity critical > critical-fixes.txt
 
 if [ -s critical-fixes.txt ]; then
   echo "CRITICAL vulnerabilities found!"
@@ -2664,10 +2664,10 @@ Discover shortest attack paths from entry points to high-value targets:
 
 ```bash
 # Find attack paths in a graph
-threat-radar graph attack-paths graph.graphml
+tr graph attack-paths graph.graphml
 
 # Limit number of paths and save to JSON
-threat-radar graph attack-paths graph.graphml \
+tr graph attack-paths graph.graphml \
   --max-paths 20 \
   --max-length 10 \
   -o attack-paths.json
@@ -2692,10 +2692,10 @@ Identify opportunities for attackers to escalate privileges:
 
 ```bash
 # Find privilege escalation paths
-threat-radar graph privilege-escalation graph.graphml
+tr graph privilege-escalation graph.graphml
 
 # Limit results and save output
-threat-radar graph privilege-escalation graph.graphml \
+tr graph privilege-escalation graph.graphml \
   --max-paths 20 \
   -o privilege-escalation.json
 
@@ -2718,10 +2718,10 @@ Find lateral movement opportunities within the infrastructure:
 
 ```bash
 # Identify lateral movement opportunities
-threat-radar graph lateral-movement graph.graphml
+tr graph lateral-movement graph.graphml
 
 # Customize search parameters
-threat-radar graph lateral-movement graph.graphml \
+tr graph lateral-movement graph.graphml \
   --max-opportunities 30 \
   -o lateral-movement.json
 
@@ -2744,10 +2744,10 @@ Combine all attack path analysis into a complete security assessment:
 
 ```bash
 # Full attack surface analysis
-threat-radar graph attack-surface graph.graphml
+tr graph attack-surface graph.graphml
 
 # Comprehensive analysis with custom limits
-threat-radar graph attack-surface graph.graphml \
+tr graph attack-surface graph.graphml \
   --max-paths 50 \
   -o attack-surface.json
 
@@ -2775,27 +2775,27 @@ threat-radar graph attack-surface graph.graphml \
 # complete-attack-analysis.sh
 
 # 1. Build environment graph with vulnerability data
-threat-radar env build-graph production-env.json \
+tr env build-graph production-env.json \
   --merge-scan scan-results-1.json \
   --merge-scan scan-results-2.json \
   -o complete-graph.graphml
 
 # 2. Analyze all attack vectors
-threat-radar graph attack-surface complete-graph.graphml \
+tr graph attack-surface complete-graph.graphml \
   -o attack-surface.json
 
 # 3. Find critical attack paths
-threat-radar graph attack-paths complete-graph.graphml \
+tr graph attack-paths complete-graph.graphml \
   --max-paths 50 \
   -o critical-paths.json
 
 # 4. Detect privilege escalation opportunities
-threat-radar graph privilege-escalation complete-graph.graphml \
+tr graph privilege-escalation complete-graph.graphml \
   --max-paths 20 \
   -o privesc.json
 
 # 5. Identify lateral movement risks
-threat-radar graph lateral-movement complete-graph.graphml \
+tr graph lateral-movement complete-graph.graphml \
   --max-opportunities 30 \
   -o lateral.json
 
@@ -2814,7 +2814,7 @@ jq -r '.recommendations[]' attack-surface.json
 GRAPH="production-graph.graphml"
 
 # Find all critical-severity attack paths
-threat-radar graph attack-paths $GRAPH -o paths.json
+tr graph attack-paths $GRAPH -o paths.json
 
 # Extract critical paths
 CRITICAL=$(jq -r '.attack_paths[] | select(.threat_level=="critical") | .path_id' paths.json)
@@ -2849,9 +2849,9 @@ BASELINE="baseline-attack-surface.json"
 CURRENT="current-attack-surface.json"
 
 # Scan current state
-threat-radar cve scan-image production:latest --auto-save -o scan.json
-threat-radar graph build scan.json -o graph.graphml
-threat-radar graph attack-surface graph.graphml -o $CURRENT
+tr cve scan-image production:latest --auto-save -o scan.json
+tr graph build scan.json -o graph.graphml
+tr graph attack-surface graph.graphml -o $CURRENT
 
 # Compare with baseline
 BASELINE_RISK=$(jq -r '.total_risk_score' $BASELINE)
@@ -2894,13 +2894,13 @@ Attack path analysis integrates with environment configuration for business-awar
 ENV_FILE="production-environment.json"
 
 # 1. Build graph with environment context
-threat-radar env build-graph $ENV_FILE \
+tr env build-graph $ENV_FILE \
   --merge-scan scan1.json \
   --merge-scan scan2.json \
   -o context-graph.graphml
 
 # 2. Find attack paths to critical business assets
-threat-radar graph attack-paths context-graph.graphml -o paths.json
+tr graph attack-paths context-graph.graphml -o paths.json
 
 # 3. Filter paths targeting PCI-scoped assets
 jq '.attack_paths[] | select(.target | contains("asset-payment"))' paths.json \
@@ -3106,13 +3106,13 @@ Validate environment configuration file syntax and schema:
 
 ```bash
 # Validate configuration file
-threat-radar env validate my-environment.json
+tr env validate my-environment.json
 
 # Show detailed validation errors
-threat-radar env validate my-environment.json --errors
+tr env validate my-environment.json --errors
 
 # Validate and show risk summary
-threat-radar env validate production-env.json
+tr env validate production-env.json
 ```
 
 **Validation checks:**
@@ -3145,13 +3145,13 @@ Build graph database from environment configuration:
 
 ```bash
 # Build graph from environment config
-threat-radar env build-graph my-environment.json -o infrastructure.graphml
+tr env build-graph my-environment.json -o infrastructure.graphml
 
 # Auto-save to storage/graph_storage/
-threat-radar env build-graph production-env.json --auto-save
+tr env build-graph production-env.json --auto-save
 
 # Merge with vulnerability scan results
-threat-radar env build-graph my-environment.json \
+tr env build-graph my-environment.json \
   --merge-scan scan-results-1.json \
   --merge-scan scan-results-2.json \
   --auto-save
@@ -3174,18 +3174,18 @@ threat-radar env build-graph my-environment.json \
 **Use cases:**
 ```bash
 # Build infrastructure topology graph
-threat-radar env build-graph production.json --auto-save
+tr env build-graph production.json --auto-save
 
 # Merge infrastructure with vulnerability scans
-threat-radar cve scan-image payment-api:v2.1.0 -o scan1.json
-threat-radar cve scan-image frontend:latest -o scan2.json
-threat-radar env build-graph production.json \
+tr cve scan-image payment-api:v2.1.0 -o scan1.json
+tr cve scan-image frontend:latest -o scan2.json
+tr env build-graph production.json \
   --merge-scan scan1.json \
   --merge-scan scan2.json \
   -o complete-risk-graph.graphml
 
 # Query merged graph for business-context-aware analysis
-threat-radar graph query complete-risk-graph.graphml --stats
+tr graph query complete-risk-graph.graphml --stats
 ```
 
 #### Analyze Risk with Business Context
@@ -3194,18 +3194,18 @@ Perform AI-powered risk analysis incorporating business context:
 
 ```bash
 # Analyze vulnerabilities with business context
-threat-radar env analyze-risk my-environment.json scan-results.json
+tr env analyze-risk my-environment.json scan-results.json
 
 # Use specific AI provider
-threat-radar env analyze-risk production.json scan.json \
+tr env analyze-risk production.json scan.json \
   --ai-provider anthropic \
   --ai-model claude-3-5-sonnet-20241022
 
 # Save analysis results
-threat-radar env analyze-risk env.json scan.json -o risk-analysis.json
+tr env analyze-risk env.json scan.json -o risk-analysis.json
 
 # Auto-save to storage/ai_analysis/
-threat-radar env analyze-risk production.json scan.json --auto-save
+tr env analyze-risk production.json scan.json --auto-save
 ```
 
 **Business context-aware analysis includes:**
@@ -3274,7 +3274,7 @@ ENV_FILE="production-environment.json"
 
 # 1. Validate environment configuration
 echo "Validating environment configuration..."
-threat-radar env validate $ENV_FILE
+tr env validate $ENV_FILE
 
 # 2. Scan all assets for vulnerabilities
 echo "Scanning assets..."
@@ -3282,23 +3282,23 @@ SCANS=()
 for asset in $(jq -r '.assets[].software.image' $ENV_FILE | grep -v null); do
   echo "  Scanning $asset..."
   scan_file="scan-${asset//[:\/]/_}.json"
-  threat-radar cve scan-image $asset --auto-save -o $scan_file
+  tr cve scan-image $asset --auto-save -o $scan_file
   SCANS+=("--merge-scan $scan_file")
 done
 
 # 3. Build infrastructure graph with vulnerabilities
 echo "Building infrastructure graph..."
-threat-radar env build-graph $ENV_FILE ${SCANS[@]} --auto-save
+tr env build-graph $ENV_FILE ${SCANS[@]} --auto-save
 
 # 4. Perform business context-aware risk analysis
 echo "Analyzing risk with business context..."
 for scan in scan-*.json; do
-  threat-radar env analyze-risk $ENV_FILE $scan --auto-save
+  tr env analyze-risk $ENV_FILE $scan --auto-save
 done
 
 # 5. Generate executive report
 echo "Generating executive report..."
-threat-radar report generate scan-*.json \
+tr report generate scan-*.json \
   -o executive-risk-report.html \
   -f html \
   --level executive \
@@ -3330,17 +3330,17 @@ jobs:
 
       - name: Scan for Vulnerabilities
         run: |
-          threat-radar cve scan-image app:${{ github.sha }} \
+          tr cve scan-image app:${{ github.sha }} \
             --auto-save -o scan.json
 
       - name: Validate Environment Config
-        run: threat-radar env validate .threat-radar/production-env.json
+        run: tr env validate .threat-radar/production-env.json
 
       - name: Analyze with Business Context
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          threat-radar env analyze-risk \
+          tr env analyze-risk \
             .threat-radar/production-env.json \
             scan.json \
             -o risk-analysis.json
@@ -3371,19 +3371,19 @@ jq -r '.assets[] | select(.business_context.pci_scope == true) | .software.image
 while read -r image; do
   if [ -n "$image" ]; then
     echo "  Scanning $image..."
-    threat-radar cve scan-image $image --auto-save
+    tr cve scan-image $image --auto-save
   fi
 done
 
 # Build infrastructure graph with scans
 echo "Building compliance risk graph..."
-threat-radar env build-graph $ENV_FILE \
+tr env build-graph $ENV_FILE \
   --merge-scan storage/cve_storage/*.json \
   -o compliance-risk-${QUARTER}.graphml
 
 # Generate compliance report
 echo "Generating compliance report..."
-threat-radar env analyze-risk $ENV_FILE storage/cve_storage/*.json \
+tr env analyze-risk $ENV_FILE storage/cve_storage/*.json \
   -o compliance-report-${QUARTER}.json \
   --ai-provider openai
 
@@ -3749,28 +3749,28 @@ Create interactive vulnerability graph visualizations:
 
 ```bash
 # Create basic interactive graph
-threat-radar visualize graph graph.graphml -o visualization.html
+tr visualize graph graph.graphml -o visualization.html
 
 # Open visualization in browser automatically
-threat-radar visualize graph graph.graphml -o viz.html --open
+tr visualize graph graph.graphml -o viz.html --open
 
 # Use different layout algorithm
-threat-radar visualize graph graph.graphml -o viz.html \
+tr visualize graph graph.graphml -o viz.html \
   --layout hierarchical
 
 # Color by severity instead of node type
-threat-radar visualize graph graph.graphml -o viz.html \
+tr visualize graph graph.graphml -o viz.html \
   --color-by severity
 
 # Create 3D visualization
-threat-radar visualize graph graph.graphml -o viz.html --3d
+tr visualize graph graph.graphml -o viz.html --3d
 
 # Custom dimensions
-threat-radar visualize graph graph.graphml -o viz.html \
+tr visualize graph graph.graphml -o viz.html \
   --width 1600 --height 1000
 
 # Hide node labels for cleaner view
-threat-radar visualize graph graph.graphml -o viz.html --no-labels
+tr visualize graph graph.graphml -o viz.html --no-labels
 ```
 
 **Layout algorithms:**
@@ -3790,22 +3790,22 @@ Visualize attack paths with highlighted routes:
 
 ```bash
 # Visualize attack paths from graph analysis
-threat-radar visualize attack-paths graph.graphml -o attack-paths.html
+tr visualize attack-paths graph.graphml -o attack-paths.html
 
 # Use pre-calculated attack paths JSON
-threat-radar visualize attack-paths graph.graphml -o paths.html \
+tr visualize attack-paths graph.graphml -o paths.html \
   --paths attack-paths.json
 
 # Show only top 10 most critical paths
-threat-radar visualize attack-paths graph.graphml -o paths.html \
+tr visualize attack-paths graph.graphml -o paths.html \
   --max-paths 10
 
 # Hierarchical layout for clearer attack flows
-threat-radar visualize attack-paths graph.graphml -o paths.html \
+tr visualize attack-paths graph.graphml -o paths.html \
   --layout hierarchical
 
 # Custom dimensions for presentation
-threat-radar visualize attack-paths graph.graphml -o paths.html \
+tr visualize attack-paths graph.graphml -o paths.html \
   --width 1920 --height 1080 --open
 ```
 
@@ -3822,26 +3822,26 @@ Visualize network topology with security context:
 
 ```bash
 # Basic topology visualization
-threat-radar visualize topology graph.graphml -o topology.html
+tr visualize topology graph.graphml -o topology.html
 
 # Security zones view
-threat-radar visualize topology graph.graphml -o zones.html \
+tr visualize topology graph.graphml -o zones.html \
   --view zones
 
 # Compliance scope view
-threat-radar visualize topology graph.graphml -o compliance.html \
+tr visualize topology graph.graphml -o compliance.html \
   --view compliance
 
 # Specific compliance type (PCI-DSS)
-threat-radar visualize topology graph.graphml -o pci.html \
+tr visualize topology graph.graphml -o pci.html \
   --view compliance --compliance pci
 
 # Color by criticality
-threat-radar visualize topology graph.graphml -o topology.html \
+tr visualize topology graph.graphml -o topology.html \
   --color-by criticality
 
 # Color by compliance scope
-threat-radar visualize topology graph.graphml -o topology.html \
+tr visualize topology graph.graphml -o topology.html \
   --color-by compliance
 ```
 
@@ -3861,43 +3861,43 @@ Apply filters to focus on specific graph subsets:
 
 ```bash
 # Filter by severity (show only HIGH+ vulnerabilities)
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type severity --value high
 
 # Filter by node type (show only vulnerabilities and packages)
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type node_type --values vulnerability package
 
 # Filter by specific CVE
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type cve --values CVE-2023-1234 CVE-2023-5678
 
 # Filter by package name
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type package --values openssl curl
 
 # Filter by security zone
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type zone --values dmz internal
 
 # Filter by criticality
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type criticality --value critical
 
 # Filter by compliance scope
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type compliance --values pci hipaa
 
 # Filter internet-facing assets only
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type internet_facing
 
 # Search for specific terms
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type search --value "openssl"
 
 # Exclude related nodes (show only filtered nodes)
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type severity --value critical --no-related
 ```
 
@@ -3918,43 +3918,43 @@ Export visualizations to various formats:
 
 ```bash
 # Export as HTML only
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format html
 
 # Export as PNG image
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format png
 
 # Export as high-resolution SVG
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format svg
 
 # Export as PDF for reports
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format pdf
 
 # Export as JSON for web applications
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format json
 
 # Export as DOT for Graphviz
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format dot
 
 # Export as Cytoscape.js format
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format cytoscape
 
 # Export as GEXF for Gephi
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format gexf
 
 # Export multiple formats at once
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format html --format png --format json
 
 # Custom layout for exported visualizations
-threat-radar visualize export graph.graphml -o viz \
+tr visualize export graph.graphml -o viz \
   --format html --format png --layout hierarchical
 ```
 
@@ -3974,7 +3974,7 @@ See available filter values before filtering:
 
 ```bash
 # Show all available filter values
-threat-radar visualize stats graph.graphml
+tr visualize stats graph.graphml
 ```
 
 **Output includes:**
@@ -3997,29 +3997,29 @@ threat-radar visualize stats graph.graphml
 IMAGE="myapp:production"
 
 # 1. Scan image for vulnerabilities
-threat-radar cve scan-image $IMAGE --auto-save -o scan.json
+tr cve scan-image $IMAGE --auto-save -o scan.json
 
 # 2. Build vulnerability graph
-threat-radar graph build scan.json --auto-save -o vuln.graphml
+tr graph build scan.json --auto-save -o vuln.graphml
 
 # 3. Create basic interactive visualization
-threat-radar visualize graph vuln.graphml -o viz-overview.html \
+tr visualize graph vuln.graphml -o viz-overview.html \
   --layout hierarchical --open
 
 # 4. Analyze attack paths
-threat-radar graph attack-paths vuln.graphml \
+tr graph attack-paths vuln.graphml \
   --max-paths 20 -o attack-paths.json
 
 # 5. Visualize attack paths
-threat-radar visualize attack-paths vuln.graphml -o viz-attack-paths.html \
+tr visualize attack-paths vuln.graphml -o viz-attack-paths.html \
   --paths attack-paths.json --max-paths 10
 
 # 6. Create filtered view of critical issues
-threat-radar visualize filter vuln.graphml -o viz-critical.html \
+tr visualize filter vuln.graphml -o viz-critical.html \
   --type severity --value critical
 
 # 7. Export to multiple formats for reporting
-threat-radar visualize export vuln.graphml -o reports/vuln-graph \
+tr visualize export vuln.graphml -o reports/vuln-graph \
   --format html --format png --format pdf
 
 echo "✅ Visualization workflow complete!"
@@ -4038,32 +4038,32 @@ echo "   - Reports: reports/vuln-graph.*"
 ENV_FILE="production-environment.json"
 
 # 1. Build environment graph with vulnerability data
-threat-radar env build-graph $ENV_FILE \
+tr env build-graph $ENV_FILE \
   --merge-scan scan1.json \
   --merge-scan scan2.json \
   --auto-save -o env-graph.graphml
 
 # 2. Create full topology view
-threat-radar visualize topology env-graph.graphml -o topology-full.html \
+tr visualize topology env-graph.graphml -o topology-full.html \
   --view topology --color-by zone
 
 # 3. Create security zones view
-threat-radar visualize topology env-graph.graphml -o topology-zones.html \
+tr visualize topology env-graph.graphml -o topology-zones.html \
   --view zones
 
 # 4. Create compliance scope view (PCI-DSS)
-threat-radar visualize topology env-graph.graphml -o topology-pci.html \
+tr visualize topology env-graph.graphml -o topology-pci.html \
   --view compliance --compliance pci
 
 # 5. Filter to show only internet-facing assets
-threat-radar visualize filter env-graph.graphml -o topology-external.html \
+tr visualize filter env-graph.graphml -o topology-external.html \
   --type internet_facing
 
 # 6. Analyze attack paths in environment
-threat-radar graph attack-paths env-graph.graphml \
+tr graph attack-paths env-graph.graphml \
   --max-paths 50 -o env-attack-paths.json
 
-threat-radar visualize attack-paths env-graph.graphml \
+tr visualize attack-paths env-graph.graphml \
   -o topology-attacks.html --paths env-attack-paths.json
 
 echo "✅ Topology visualization complete!"
@@ -4078,24 +4078,24 @@ echo "✅ Topology visualization complete!"
 GRAPH_FILE="production-graph.graphml"
 
 # Show filter statistics
-threat-radar visualize stats $GRAPH_FILE
+tr visualize stats $GRAPH_FILE
 
 # Create PCI-DSS compliance view
-threat-radar visualize topology $GRAPH_FILE -o compliance-pci.html \
+tr visualize topology $GRAPH_FILE -o compliance-pci.html \
   --view compliance --compliance pci
 
-threat-radar visualize filter $GRAPH_FILE -o compliance-pci-critical.html \
+tr visualize filter $GRAPH_FILE -o compliance-pci-critical.html \
   --type compliance --values pci \
-  | threat-radar visualize filter - -o compliance-pci-critical.html \
+  | tr visualize filter - -o compliance-pci-critical.html \
     --type severity --value critical
 
 # Create HIPAA compliance view
-threat-radar visualize topology $GRAPH_FILE -o compliance-hipaa.html \
+tr visualize topology $GRAPH_FILE -o compliance-hipaa.html \
   --view compliance --compliance hipaa
 
 # Export compliance reports
 for compliance in pci hipaa sox gdpr; do
-  threat-radar visualize export $GRAPH_FILE \
+  tr visualize export $GRAPH_FILE \
     -o reports/compliance-${compliance} \
     --format html --format pdf
 done
@@ -4246,15 +4246,15 @@ For graphs with thousands of nodes:
 
 ```bash
 # Use filtering to reduce graph size
-threat-radar visualize filter graph.graphml -o filtered.html \
+tr visualize filter graph.graphml -o filtered.html \
   --type severity --value high --no-related
 
 # Or use simpler layout algorithms
-threat-radar visualize graph graph.graphml -o viz.html \
+tr visualize graph graph.graphml -o viz.html \
   --layout circular --no-labels
 
 # Export as JSON for custom web rendering
-threat-radar visualize export graph.graphml -o data.json \
+tr visualize export graph.graphml -o data.json \
   --format json
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ cp .env.example .env
 
 ```bash
 # Check CLI is working
-threat-radar --help
+tr --help
 
 # Run a quick scan
-threat-radar cve scan-image alpine:3.18
+tr cve scan-image alpine:3.18
 ```
 
 ---
@@ -101,77 +101,77 @@ threat-radar cve scan-image alpine:3.18
 
 ```bash
 # Scan Docker image for vulnerabilities
-threat-radar cve scan-image alpine:3.18
+tr cve scan-image alpine:3.18
 
 # Scan with severity filter
-threat-radar cve scan-image python:3.11 --severity HIGH
+tr cve scan-image python:3.11 --severity HIGH
 
 # Save results and auto-cleanup
-threat-radar cve scan-image nginx:latest --auto-save --cleanup
+tr cve scan-image nginx:latest --auto-save --cleanup
 
 # Scan SBOM file
-threat-radar cve scan-sbom my-app-sbom.json --severity CRITICAL
+tr cve scan-sbom my-app-sbom.json --severity CRITICAL
 
 # Scan local directory
-threat-radar cve scan-directory ./my-project
+tr cve scan-directory ./my-project
 ```
 
 ### SBOM Generation
 
 ```bash
 # Generate SBOM from Docker image
-threat-radar sbom docker alpine:3.18 -o sbom.json
+tr sbom docker alpine:3.18 -o sbom.json
 
 # Generate from local directory
-threat-radar sbom generate ./my-app -f cyclonedx-json
+tr sbom generate ./my-app -f cyclonedx-json
 
 # Auto-save to organized storage
-threat-radar sbom docker python:3.11 --auto-save
+tr sbom docker python:3.11 --auto-save
 
 # Compare two SBOMs
-threat-radar sbom compare alpine:3.17 alpine:3.18
+tr sbom compare alpine:3.17 alpine:3.18
 ```
 
 ### AI-Powered Analysis
 
 ```bash
 # Analyze vulnerabilities with AI
-threat-radar ai analyze scan-results.json
+tr ai analyze scan-results.json
 
 # Generate prioritized remediation list
-threat-radar ai prioritize scan-results.json --top 10
+tr ai prioritize scan-results.json --top 10
 
 # Create remediation plan
-threat-radar ai remediate scan-results.json -o remediation.json
+tr ai remediate scan-results.json -o remediation.json
 ```
 
 ### Comprehensive Reporting
 
 ```bash
 # Generate HTML report with AI executive summary
-threat-radar report generate scan-results.json -o report.html -f html
+tr report generate scan-results.json -o report.html -f html
 
 # Executive summary for leadership
-threat-radar report generate scan-results.json -o exec.md -f markdown --level executive
+tr report generate scan-results.json -o exec.md -f markdown --level executive
 
 # Critical-only issues
-threat-radar report generate scan-results.json --level critical-only
+tr report generate scan-results.json --level critical-only
 
 # Export dashboard data
-threat-radar report dashboard-export scan-results.json -o dashboard.json
+tr report dashboard-export scan-results.json -o dashboard.json
 ```
 
 ### Docker Analysis
 
 ```bash
 # Import and analyze image
-threat-radar docker import-image ubuntu:22.04 -o analysis.json
+tr docker import-image ubuntu:22.04 -o analysis.json
 
 # List packages in image
-threat-radar docker packages alpine:3.18 --limit 20
+tr docker packages alpine:3.18 --limit 20
 
 # Generate Python SBOM
-threat-radar docker python-sbom python:3.11 -o sbom.json
+tr docker python-sbom python:3.11 -o sbom.json
 ```
 
 ---
@@ -210,7 +210,7 @@ threat-radar docker python-sbom python:3.11 -o sbom.json
 
 ```bash
 # Scan with all features
-threat-radar cve scan-image myapp:latest \
+tr cve scan-image myapp:latest \
   --severity HIGH \
   --auto-save \
   --cleanup \
@@ -227,10 +227,10 @@ threat-radar cve scan-image myapp:latest \
 
 ```bash
 # Complete AI workflow
-threat-radar cve scan-image alpine:3.18 --auto-save -o scan.json
-threat-radar ai analyze scan.json --auto-save
-threat-radar ai prioritize scan.json --top 10
-threat-radar ai remediate scan.json -o plan.json
+tr cve scan-image alpine:3.18 --auto-save -o scan.json
+tr ai analyze scan.json --auto-save
+tr ai prioritize scan.json --top 10
+tr ai remediate scan.json -o plan.json
 ```
 
 ### 📊 Comprehensive Reporting
@@ -243,9 +243,9 @@ threat-radar ai remediate scan.json -o plan.json
 
 ```bash
 # Generate reports for different audiences
-threat-radar report generate scan.json -o exec.md --level executive  # Leadership
-threat-radar report generate scan.json -o detailed.html --level detailed  # Security team
-threat-radar report generate scan.json -o critical.json --level critical-only  # DevOps
+tr report generate scan.json -o exec.md --level executive  # Leadership
+tr report generate scan.json -o detailed.html --level detailed  # Security team
+tr report generate scan.json -o critical.json --level critical-only  # DevOps
 ```
 
 ### 📦 SBOM Generation (Syft-Powered)
@@ -259,9 +259,9 @@ threat-radar report generate scan.json -o critical.json --level critical-only  #
 
 ```bash
 # Generate and compare SBOMs
-threat-radar sbom docker myapp:v1.0 --auto-save
-threat-radar sbom docker myapp:v2.0 --auto-save
-threat-radar sbom compare myapp:v1.0 myapp:v2.0
+tr sbom docker myapp:v1.0 --auto-save
+tr sbom docker myapp:v2.0 --auto-save
+tr sbom compare myapp:v1.0 myapp:v2.0
 ```
 
 ### 🐳 Docker Integration
@@ -464,18 +464,18 @@ IMAGE="myapp:production"
 WEEK=$(date +%Y-W%U)
 
 # 1. Scan for vulnerabilities
-threat-radar cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
+tr cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
 
 # 2. Generate reports
-threat-radar report generate scan-${WEEK}.json -o exec-${WEEK}.md --level executive
-threat-radar report generate scan-${WEEK}.json -o detailed-${WEEK}.html -f html
+tr report generate scan-${WEEK}.json -o exec-${WEEK}.md --level executive
+tr report generate scan-${WEEK}.json -o detailed-${WEEK}.html -f html
 
 # 3. AI analysis
-threat-radar ai analyze scan-${WEEK}.json --auto-save
-threat-radar ai prioritize scan-${WEEK}.json --top 10 -o priorities-${WEEK}.json
+tr ai analyze scan-${WEEK}.json --auto-save
+tr ai prioritize scan-${WEEK}.json --top 10 -o priorities-${WEEK}.json
 
 # 4. Export dashboard data
-threat-radar report dashboard-export scan-${WEEK}.json -o dashboard-${WEEK}.json
+tr report dashboard-export scan-${WEEK}.json -o dashboard-${WEEK}.json
 ```
 
 ### CI/CD Integration
@@ -503,12 +503,12 @@ jobs:
 
       - name: Scan for vulnerabilities
         run: |
-          threat-radar cve scan-image app:${{ github.sha }} \
+          tr cve scan-image app:${{ github.sha }} \
             --auto-save --cleanup -o scan.json
 
       - name: Check for critical issues
         run: |
-          threat-radar report generate scan.json \
+          tr report generate scan.json \
             --level critical-only -o critical.json
 
           CRITICAL=$(jq '.summary.critical' critical.json)

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ cp .env.example .env
 
 ```bash
 # Check CLI is working
-tr --help
+tradar --help
 
 # Run a quick scan
-tr cve scan-image alpine:3.18
+tradar cve scan-image alpine:3.18
 ```
 
 ---
@@ -101,77 +101,77 @@ tr cve scan-image alpine:3.18
 
 ```bash
 # Scan Docker image for vulnerabilities
-tr cve scan-image alpine:3.18
+tradar cve scan-image alpine:3.18
 
 # Scan with severity filter
-tr cve scan-image python:3.11 --severity HIGH
+tradar cve scan-image python:3.11 --severity HIGH
 
 # Save results and auto-cleanup
-tr cve scan-image nginx:latest --auto-save --cleanup
+tradar cve scan-image nginx:latest --auto-save --cleanup
 
 # Scan SBOM file
-tr cve scan-sbom my-app-sbom.json --severity CRITICAL
+tradar cve scan-sbom my-app-sbom.json --severity CRITICAL
 
 # Scan local directory
-tr cve scan-directory ./my-project
+tradar cve scan-directory ./my-project
 ```
 
 ### SBOM Generation
 
 ```bash
 # Generate SBOM from Docker image
-tr sbom docker alpine:3.18 -o sbom.json
+tradar sbom docker alpine:3.18 -o sbom.json
 
 # Generate from local directory
-tr sbom generate ./my-app -f cyclonedx-json
+tradar sbom generate ./my-app -f cyclonedx-json
 
 # Auto-save to organized storage
-tr sbom docker python:3.11 --auto-save
+tradar sbom docker python:3.11 --auto-save
 
 # Compare two SBOMs
-tr sbom compare alpine:3.17 alpine:3.18
+tradar sbom compare alpine:3.17 alpine:3.18
 ```
 
 ### AI-Powered Analysis
 
 ```bash
 # Analyze vulnerabilities with AI
-tr ai analyze scan-results.json
+tradar ai analyze scan-results.json
 
 # Generate prioritized remediation list
-tr ai prioritize scan-results.json --top 10
+tradar ai prioritize scan-results.json --top 10
 
 # Create remediation plan
-tr ai remediate scan-results.json -o remediation.json
+tradar ai remediate scan-results.json -o remediation.json
 ```
 
 ### Comprehensive Reporting
 
 ```bash
 # Generate HTML report with AI executive summary
-tr report generate scan-results.json -o report.html -f html
+tradar report generate scan-results.json -o report.html -f html
 
 # Executive summary for leadership
-tr report generate scan-results.json -o exec.md -f markdown --level executive
+tradar report generate scan-results.json -o exec.md -f markdown --level executive
 
 # Critical-only issues
-tr report generate scan-results.json --level critical-only
+tradar report generate scan-results.json --level critical-only
 
 # Export dashboard data
-tr report dashboard-export scan-results.json -o dashboard.json
+tradar report dashboard-export scan-results.json -o dashboard.json
 ```
 
 ### Docker Analysis
 
 ```bash
 # Import and analyze image
-tr docker import-image ubuntu:22.04 -o analysis.json
+tradar docker import-image ubuntu:22.04 -o analysis.json
 
 # List packages in image
-tr docker packages alpine:3.18 --limit 20
+tradar docker packages alpine:3.18 --limit 20
 
 # Generate Python SBOM
-tr docker python-sbom python:3.11 -o sbom.json
+tradar docker python-sbom python:3.11 -o sbom.json
 ```
 
 ---
@@ -210,7 +210,7 @@ tr docker python-sbom python:3.11 -o sbom.json
 
 ```bash
 # Scan with all features
-tr cve scan-image myapp:latest \
+tradar cve scan-image myapp:latest \
   --severity HIGH \
   --auto-save \
   --cleanup \
@@ -227,10 +227,10 @@ tr cve scan-image myapp:latest \
 
 ```bash
 # Complete AI workflow
-tr cve scan-image alpine:3.18 --auto-save -o scan.json
-tr ai analyze scan.json --auto-save
-tr ai prioritize scan.json --top 10
-tr ai remediate scan.json -o plan.json
+tradar cve scan-image alpine:3.18 --auto-save -o scan.json
+tradar ai analyze scan.json --auto-save
+tradar ai prioritize scan.json --top 10
+tradar ai remediate scan.json -o plan.json
 ```
 
 ### 📊 Comprehensive Reporting
@@ -243,9 +243,9 @@ tr ai remediate scan.json -o plan.json
 
 ```bash
 # Generate reports for different audiences
-tr report generate scan.json -o exec.md --level executive  # Leadership
-tr report generate scan.json -o detailed.html --level detailed  # Security team
-tr report generate scan.json -o critical.json --level critical-only  # DevOps
+tradar report generate scan.json -o exec.md --level executive  # Leadership
+tradar report generate scan.json -o detailed.html --level detailed  # Security team
+tradar report generate scan.json -o critical.json --level critical-only  # DevOps
 ```
 
 ### 📦 SBOM Generation (Syft-Powered)
@@ -259,9 +259,9 @@ tr report generate scan.json -o critical.json --level critical-only  # DevOps
 
 ```bash
 # Generate and compare SBOMs
-tr sbom docker myapp:v1.0 --auto-save
-tr sbom docker myapp:v2.0 --auto-save
-tr sbom compare myapp:v1.0 myapp:v2.0
+tradar sbom docker myapp:v1.0 --auto-save
+tradar sbom docker myapp:v2.0 --auto-save
+tradar sbom compare myapp:v1.0 myapp:v2.0
 ```
 
 ### 🐳 Docker Integration
@@ -464,18 +464,18 @@ IMAGE="myapp:production"
 WEEK=$(date +%Y-W%U)
 
 # 1. Scan for vulnerabilities
-tr cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
+tradar cve scan-image $IMAGE --auto-save -o scan-${WEEK}.json
 
 # 2. Generate reports
-tr report generate scan-${WEEK}.json -o exec-${WEEK}.md --level executive
-tr report generate scan-${WEEK}.json -o detailed-${WEEK}.html -f html
+tradar report generate scan-${WEEK}.json -o exec-${WEEK}.md --level executive
+tradar report generate scan-${WEEK}.json -o detailed-${WEEK}.html -f html
 
 # 3. AI analysis
-tr ai analyze scan-${WEEK}.json --auto-save
-tr ai prioritize scan-${WEEK}.json --top 10 -o priorities-${WEEK}.json
+tradar ai analyze scan-${WEEK}.json --auto-save
+tradar ai prioritize scan-${WEEK}.json --top 10 -o priorities-${WEEK}.json
 
 # 4. Export dashboard data
-tr report dashboard-export scan-${WEEK}.json -o dashboard-${WEEK}.json
+tradar report dashboard-export scan-${WEEK}.json -o dashboard-${WEEK}.json
 ```
 
 ### CI/CD Integration
@@ -503,12 +503,12 @@ jobs:
 
       - name: Scan for vulnerabilities
         run: |
-          tr cve scan-image app:${{ github.sha }} \
+          tradar cve scan-image app:${{ github.sha }} \
             --auto-save --cleanup -o scan.json
 
       - name: Check for critical issues
         run: |
-          tr report generate scan.json \
+          tradar report generate scan.json \
             --level critical-only -o critical.json
 
           CRITICAL=$(jq '.summary.critical' critical.json)

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,8 +71,8 @@ make docker-shell
 make docker-shell-project PROJECT=/path/to/project
 
 # Inside container:
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/my-project.json
-$ threat-radar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+$ tr sbom generate /workspace -o /app/sbom_storage/my-project.json
+$ tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 ```
 
 ## Storage

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,8 +71,8 @@ make docker-shell
 make docker-shell-project PROJECT=/path/to/project
 
 # Inside container:
-$ tr sbom generate /workspace -o /app/sbom_storage/my-project.json
-$ tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+$ tradar sbom generate /workspace -o /app/sbom_storage/my-project.json
+$ tradar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 ```
 
 ## Storage

--- a/docker/quick-test.sh
+++ b/docker/quick-test.sh
@@ -16,10 +16,10 @@ cat << 'EOF'
 # ============================================================================
 
 # Check help
-tr --help
+tradar --help
 
 # Health check
-tr health check
+tradar health check
 
 # Check Docker access
 docker ps
@@ -29,64 +29,64 @@ docker ps
 # ============================================================================
 
 # Small image - Alpine
-tr sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
+tradar sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
 
 # View SBOM
-tr sbom read /app/sbom_storage/alpine.json
+tradar sbom read /app/sbom_storage/alpine.json
 
 # SBOM stats
-tr sbom stats /app/sbom_storage/alpine.json
+tradar sbom stats /app/sbom_storage/alpine.json
 
 # ============================================================================
 # 3. CVE SCANNING (Quick)
 # ============================================================================
 
 # Scan Alpine
-tr cve scan-image alpine:3.18 -o /tmp/alpine-scan.json
+tradar cve scan-image alpine:3.18 -o /tmp/alpine-scan.json
 
 # Scan with severity filter
-tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/alpine-high.json
+tradar cve scan-image alpine:3.18 --severity HIGH -o /tmp/alpine-high.json
 
 # Scan SBOM
-tr cve scan-sbom /app/sbom_storage/alpine.json --auto-save
+tradar cve scan-sbom /app/sbom_storage/alpine.json --auto-save
 
 # ============================================================================
 # 4. GRAPH OPERATIONS
 # ============================================================================
 
 # Build graph
-tr graph build /tmp/alpine-scan.json -o /tmp/alpine-graph.graphml
+tradar graph build /tmp/alpine-scan.json -o /tmp/alpine-graph.graphml
 
 # Query graph
-tr graph query /tmp/alpine-graph.graphml --stats
+tradar graph query /tmp/alpine-graph.graphml --stats
 
 # ============================================================================
 # 5. REPORTS
 # ============================================================================
 
 # Generate JSON report
-tr report generate /tmp/alpine-scan.json -o /tmp/report.json
+tradar report generate /tmp/alpine-scan.json -o /tmp/report.json
 
 # Generate HTML report
-tr report generate /tmp/alpine-scan.json -o /tmp/report.html -f html
+tradar report generate /tmp/alpine-scan.json -o /tmp/report.html -f html
 
 # Dashboard data
-tr report dashboard-export /tmp/alpine-scan.json -o /tmp/dashboard.json
+tradar report dashboard-export /tmp/alpine-scan.json -o /tmp/dashboard.json
 
 # ============================================================================
 # 6. TEST MULTIPLE IMAGES
 # ============================================================================
 
 # Python image
-tr sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
-tr cve scan-sbom /app/sbom_storage/python.json --auto-save
+tradar sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
+tradar cve scan-sbom /app/sbom_storage/python.json --auto-save
 
 # Nginx
-tr sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
-tr cve scan-sbom /app/sbom_storage/nginx.json --auto-save
+tradar sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
+tradar cve scan-sbom /app/sbom_storage/nginx.json --auto-save
 
 # BusyBox (very small)
-tr sbom docker busybox:latest -o /app/sbom_storage/busybox.json
+tradar sbom docker busybox:latest -o /app/sbom_storage/busybox.json
 
 # ============================================================================
 # 7. LOCAL PROJECT SCANNING
@@ -96,10 +96,10 @@ tr sbom docker busybox:latest -o /app/sbom_storage/busybox.json
 # The project will be at /workspace
 
 # Generate SBOM from local project
-tr sbom generate /workspace -o /app/sbom_storage/my-project.json
+tradar sbom generate /workspace -o /app/sbom_storage/my-project.json
 
 # Scan the SBOM
-tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+tradar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 
 # View results
 ls -lh /app/storage/cve_storage/
@@ -109,16 +109,16 @@ ls -lh /app/storage/cve_storage/
 # ============================================================================
 
 # Compare SBOMs
-tr sbom compare /app/sbom_storage/alpine.json /app/sbom_storage/python.json
+tradar sbom compare /app/sbom_storage/alpine.json /app/sbom_storage/python.json
 
 # Search in SBOM
-tr sbom search /app/sbom_storage/python.json openssl
+tradar sbom search /app/sbom_storage/python.json openssl
 
 # List components
-tr sbom components /app/sbom_storage/python.json
+tradar sbom components /app/sbom_storage/python.json
 
 # Export to CSV
-tr sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
+tradar sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
 
 # ============================================================================
 # 9. CHECK RESULTS

--- a/docker/quick-test.sh
+++ b/docker/quick-test.sh
@@ -16,10 +16,10 @@ cat << 'EOF'
 # ============================================================================
 
 # Check help
-threat-radar --help
+tr --help
 
 # Health check
-threat-radar health check
+tr health check
 
 # Check Docker access
 docker ps
@@ -29,64 +29,64 @@ docker ps
 # ============================================================================
 
 # Small image - Alpine
-threat-radar sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
+tr sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
 
 # View SBOM
-threat-radar sbom read /app/sbom_storage/alpine.json
+tr sbom read /app/sbom_storage/alpine.json
 
 # SBOM stats
-threat-radar sbom stats /app/sbom_storage/alpine.json
+tr sbom stats /app/sbom_storage/alpine.json
 
 # ============================================================================
 # 3. CVE SCANNING (Quick)
 # ============================================================================
 
 # Scan Alpine
-threat-radar cve scan-image alpine:3.18 -o /tmp/alpine-scan.json
+tr cve scan-image alpine:3.18 -o /tmp/alpine-scan.json
 
 # Scan with severity filter
-threat-radar cve scan-image alpine:3.18 --severity HIGH -o /tmp/alpine-high.json
+tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/alpine-high.json
 
 # Scan SBOM
-threat-radar cve scan-sbom /app/sbom_storage/alpine.json --auto-save
+tr cve scan-sbom /app/sbom_storage/alpine.json --auto-save
 
 # ============================================================================
 # 4. GRAPH OPERATIONS
 # ============================================================================
 
 # Build graph
-threat-radar graph build /tmp/alpine-scan.json -o /tmp/alpine-graph.graphml
+tr graph build /tmp/alpine-scan.json -o /tmp/alpine-graph.graphml
 
 # Query graph
-threat-radar graph query /tmp/alpine-graph.graphml --stats
+tr graph query /tmp/alpine-graph.graphml --stats
 
 # ============================================================================
 # 5. REPORTS
 # ============================================================================
 
 # Generate JSON report
-threat-radar report generate /tmp/alpine-scan.json -o /tmp/report.json
+tr report generate /tmp/alpine-scan.json -o /tmp/report.json
 
 # Generate HTML report
-threat-radar report generate /tmp/alpine-scan.json -o /tmp/report.html -f html
+tr report generate /tmp/alpine-scan.json -o /tmp/report.html -f html
 
 # Dashboard data
-threat-radar report dashboard-export /tmp/alpine-scan.json -o /tmp/dashboard.json
+tr report dashboard-export /tmp/alpine-scan.json -o /tmp/dashboard.json
 
 # ============================================================================
 # 6. TEST MULTIPLE IMAGES
 # ============================================================================
 
 # Python image
-threat-radar sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
-threat-radar cve scan-sbom /app/sbom_storage/python.json --auto-save
+tr sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
+tr cve scan-sbom /app/sbom_storage/python.json --auto-save
 
 # Nginx
-threat-radar sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
-threat-radar cve scan-sbom /app/sbom_storage/nginx.json --auto-save
+tr sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
+tr cve scan-sbom /app/sbom_storage/nginx.json --auto-save
 
 # BusyBox (very small)
-threat-radar sbom docker busybox:latest -o /app/sbom_storage/busybox.json
+tr sbom docker busybox:latest -o /app/sbom_storage/busybox.json
 
 # ============================================================================
 # 7. LOCAL PROJECT SCANNING
@@ -96,10 +96,10 @@ threat-radar sbom docker busybox:latest -o /app/sbom_storage/busybox.json
 # The project will be at /workspace
 
 # Generate SBOM from local project
-threat-radar sbom generate /workspace -o /app/sbom_storage/my-project.json
+tr sbom generate /workspace -o /app/sbom_storage/my-project.json
 
 # Scan the SBOM
-threat-radar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 
 # View results
 ls -lh /app/storage/cve_storage/
@@ -109,16 +109,16 @@ ls -lh /app/storage/cve_storage/
 # ============================================================================
 
 # Compare SBOMs
-threat-radar sbom compare /app/sbom_storage/alpine.json /app/sbom_storage/python.json
+tr sbom compare /app/sbom_storage/alpine.json /app/sbom_storage/python.json
 
 # Search in SBOM
-threat-radar sbom search /app/sbom_storage/python.json openssl
+tr sbom search /app/sbom_storage/python.json openssl
 
 # List components
-threat-radar sbom components /app/sbom_storage/python.json
+tr sbom components /app/sbom_storage/python.json
 
 # Export to CSV
-threat-radar sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
+tr sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
 
 # ============================================================================
 # 9. CHECK RESULTS

--- a/docker/test-commands.sh
+++ b/docker/test-commands.sh
@@ -50,22 +50,22 @@ echo "=== 1. Basic Health Checks ==="
 echo ""
 
 run_test "Show help" \
-    "tr --help"
+    "tradar --help"
 
 run_test "Show version" \
-    "tr --version"
+    "tradar --version"
 
 run_test "Health ping" \
-    "tr health ping"
+    "tradar health ping"
 
 run_test "Health check" \
-    "tr health check"
+    "tradar health check"
 
 run_test "Health check verbose" \
-    "tr health check --verbose"
+    "tradar health check --verbose"
 
 run_test "Health version" \
-    "tr health version"
+    "tradar health version"
 
 # ============================================================================
 # 2. DOCKER ACCESS
@@ -92,22 +92,22 @@ echo "=== 3. SBOM Generation Tests ==="
 echo ""
 
 run_test "Generate SBOM from alpine:3.18" \
-    "tr sbom docker alpine:3.18 -o /app/sbom_storage/test_alpine.json"
+    "tradar sbom docker alpine:3.18 -o /app/sbom_storage/test_alpine.json"
 
 run_test "Read SBOM file" \
-    "tr sbom read /app/sbom_storage/test_alpine.json"
+    "tradar sbom read /app/sbom_storage/test_alpine.json"
 
 run_test "SBOM stats" \
-    "tr sbom stats /app/sbom_storage/test_alpine.json"
+    "tradar sbom stats /app/sbom_storage/test_alpine.json"
 
 run_test "List SBOM components" \
-    "tr sbom components /app/sbom_storage/test_alpine.json"
+    "tradar sbom components /app/sbom_storage/test_alpine.json"
 
 run_test "Search in SBOM" \
-    "tr sbom search /app/sbom_storage/test_alpine.json openssl"
+    "tradar sbom search /app/sbom_storage/test_alpine.json openssl"
 
 run_test "List stored SBOMs" \
-    "tr sbom list"
+    "tradar sbom list"
 
 # ============================================================================
 # 4. CVE SCANNING
@@ -116,19 +116,19 @@ echo "=== 4. CVE Scanning Tests ==="
 echo ""
 
 run_test "Scan Docker image (alpine:3.18)" \
-    "tr cve scan-image alpine:3.18 -o /tmp/test_scan_alpine.json"
+    "tradar cve scan-image alpine:3.18 -o /tmp/test_scan_alpine.json"
 
 run_test "Scan SBOM file" \
-    "tr cve scan-sbom /app/sbom_storage/test_alpine.json -o /tmp/test_scan_sbom.json"
+    "tradar cve scan-sbom /app/sbom_storage/test_alpine.json -o /tmp/test_scan_sbom.json"
 
 run_test "Scan with severity filter (HIGH)" \
-    "tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/test_scan_high.json"
+    "tradar cve scan-image alpine:3.18 --severity HIGH -o /tmp/test_scan_high.json"
 
 run_test "Scan with auto-save" \
-    "tr cve scan-image busybox:latest --auto-save"
+    "tradar cve scan-image busybox:latest --auto-save"
 
 run_test "Grype database status" \
-    "tr cve db-status"
+    "tradar cve db-status"
 
 # ============================================================================
 # 5. GRAPH OPERATIONS
@@ -137,16 +137,16 @@ echo "=== 5. Graph Operations Tests ==="
 echo ""
 
 run_test "Build graph from scan" \
-    "tr graph build /tmp/test_scan_alpine.json -o /tmp/test_graph.graphml"
+    "tradar graph build /tmp/test_scan_alpine.json -o /tmp/test_graph.graphml"
 
 run_test "Query graph stats" \
-    "tr graph query /tmp/test_graph.graphml --stats"
+    "tradar graph query /tmp/test_graph.graphml --stats"
 
 run_test "List stored graphs" \
-    "tr graph list"
+    "tradar graph list"
 
 run_test "Show graph info" \
-    "tr graph info /tmp/test_graph.graphml"
+    "tradar graph info /tmp/test_graph.graphml"
 
 # ============================================================================
 # 6. REPORT GENERATION
@@ -155,16 +155,16 @@ echo "=== 6. Report Generation Tests ==="
 echo ""
 
 run_test "Generate JSON report" \
-    "tr report generate /tmp/test_scan_alpine.json -o /tmp/test_report.json -f json"
+    "tradar report generate /tmp/test_scan_alpine.json -o /tmp/test_report.json -f json"
 
 run_test "Generate Markdown report" \
-    "tr report generate /tmp/test_scan_alpine.json -o /tmp/test_report.md -f markdown"
+    "tradar report generate /tmp/test_scan_alpine.json -o /tmp/test_report.md -f markdown"
 
 run_test "Generate HTML report" \
-    "tr report generate /tmp/test_scan_alpine.json -o /tmp/test_report.html -f html"
+    "tradar report generate /tmp/test_scan_alpine.json -o /tmp/test_report.html -f html"
 
 run_test "Dashboard export" \
-    "tr report dashboard-export /tmp/test_scan_alpine.json -o /tmp/test_dashboard.json"
+    "tradar report dashboard-export /tmp/test_scan_alpine.json -o /tmp/test_dashboard.json"
 
 # ============================================================================
 # 7. FILE SYSTEM ACCESS
@@ -209,13 +209,13 @@ echo "=== 9. Multiple Image Format Tests ==="
 echo ""
 
 run_test "Scan lightweight image (busybox)" \
-    "tr cve scan-image busybox:latest -o /tmp/test_busybox.json"
+    "tradar cve scan-image busybox:latest -o /tmp/test_busybox.json"
 
 run_test "Generate SBOM for Python image" \
-    "tr sbom docker python:3.11-alpine -o /tmp/test_python_sbom.json"
+    "tradar sbom docker python:3.11-alpine -o /tmp/test_python_sbom.json"
 
 run_test "Scan nginx image" \
-    "tr cve scan-image nginx:alpine -o /tmp/test_nginx.json"
+    "tradar cve scan-image nginx:alpine -o /tmp/test_nginx.json"
 
 # ============================================================================
 # 10. ADVANCED OPERATIONS
@@ -224,16 +224,16 @@ echo "=== 10. Advanced Operations Tests ==="
 echo ""
 
 run_test "Generate SBOM with different format" \
-    "tr sbom docker redis:alpine -o /tmp/test_redis.json"
+    "tradar sbom docker redis:alpine -o /tmp/test_redis.json"
 
 run_test "Compare two SBOMs" \
-    "tr sbom compare /app/sbom_storage/test_alpine.json /tmp/test_python_sbom.json"
+    "tradar sbom compare /app/sbom_storage/test_alpine.json /tmp/test_python_sbom.json"
 
 run_test "Export SBOM to CSV" \
-    "tr sbom export /app/sbom_storage/test_alpine.json -o /tmp/packages.csv -f csv"
+    "tradar sbom export /app/sbom_storage/test_alpine.json -o /tmp/packages.csv -f csv"
 
 run_test "Build graph with auto-save" \
-    "tr graph build /tmp/test_scan_alpine.json --auto-save"
+    "tradar graph build /tmp/test_scan_alpine.json --auto-save"
 
 # ============================================================================
 # SUMMARY

--- a/docker/test-commands.sh
+++ b/docker/test-commands.sh
@@ -50,22 +50,22 @@ echo "=== 1. Basic Health Checks ==="
 echo ""
 
 run_test "Show help" \
-    "threat-radar --help"
+    "tr --help"
 
 run_test "Show version" \
-    "threat-radar --version"
+    "tr --version"
 
 run_test "Health ping" \
-    "threat-radar health ping"
+    "tr health ping"
 
 run_test "Health check" \
-    "threat-radar health check"
+    "tr health check"
 
 run_test "Health check verbose" \
-    "threat-radar health check --verbose"
+    "tr health check --verbose"
 
 run_test "Health version" \
-    "threat-radar health version"
+    "tr health version"
 
 # ============================================================================
 # 2. DOCKER ACCESS
@@ -92,22 +92,22 @@ echo "=== 3. SBOM Generation Tests ==="
 echo ""
 
 run_test "Generate SBOM from alpine:3.18" \
-    "threat-radar sbom docker alpine:3.18 -o /app/sbom_storage/test_alpine.json"
+    "tr sbom docker alpine:3.18 -o /app/sbom_storage/test_alpine.json"
 
 run_test "Read SBOM file" \
-    "threat-radar sbom read /app/sbom_storage/test_alpine.json"
+    "tr sbom read /app/sbom_storage/test_alpine.json"
 
 run_test "SBOM stats" \
-    "threat-radar sbom stats /app/sbom_storage/test_alpine.json"
+    "tr sbom stats /app/sbom_storage/test_alpine.json"
 
 run_test "List SBOM components" \
-    "threat-radar sbom components /app/sbom_storage/test_alpine.json"
+    "tr sbom components /app/sbom_storage/test_alpine.json"
 
 run_test "Search in SBOM" \
-    "threat-radar sbom search /app/sbom_storage/test_alpine.json openssl"
+    "tr sbom search /app/sbom_storage/test_alpine.json openssl"
 
 run_test "List stored SBOMs" \
-    "threat-radar sbom list"
+    "tr sbom list"
 
 # ============================================================================
 # 4. CVE SCANNING
@@ -116,19 +116,19 @@ echo "=== 4. CVE Scanning Tests ==="
 echo ""
 
 run_test "Scan Docker image (alpine:3.18)" \
-    "threat-radar cve scan-image alpine:3.18 -o /tmp/test_scan_alpine.json"
+    "tr cve scan-image alpine:3.18 -o /tmp/test_scan_alpine.json"
 
 run_test "Scan SBOM file" \
-    "threat-radar cve scan-sbom /app/sbom_storage/test_alpine.json -o /tmp/test_scan_sbom.json"
+    "tr cve scan-sbom /app/sbom_storage/test_alpine.json -o /tmp/test_scan_sbom.json"
 
 run_test "Scan with severity filter (HIGH)" \
-    "threat-radar cve scan-image alpine:3.18 --severity HIGH -o /tmp/test_scan_high.json"
+    "tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/test_scan_high.json"
 
 run_test "Scan with auto-save" \
-    "threat-radar cve scan-image busybox:latest --auto-save"
+    "tr cve scan-image busybox:latest --auto-save"
 
 run_test "Grype database status" \
-    "threat-radar cve db-status"
+    "tr cve db-status"
 
 # ============================================================================
 # 5. GRAPH OPERATIONS
@@ -137,16 +137,16 @@ echo "=== 5. Graph Operations Tests ==="
 echo ""
 
 run_test "Build graph from scan" \
-    "threat-radar graph build /tmp/test_scan_alpine.json -o /tmp/test_graph.graphml"
+    "tr graph build /tmp/test_scan_alpine.json -o /tmp/test_graph.graphml"
 
 run_test "Query graph stats" \
-    "threat-radar graph query /tmp/test_graph.graphml --stats"
+    "tr graph query /tmp/test_graph.graphml --stats"
 
 run_test "List stored graphs" \
-    "threat-radar graph list"
+    "tr graph list"
 
 run_test "Show graph info" \
-    "threat-radar graph info /tmp/test_graph.graphml"
+    "tr graph info /tmp/test_graph.graphml"
 
 # ============================================================================
 # 6. REPORT GENERATION
@@ -155,16 +155,16 @@ echo "=== 6. Report Generation Tests ==="
 echo ""
 
 run_test "Generate JSON report" \
-    "threat-radar report generate /tmp/test_scan_alpine.json -o /tmp/test_report.json -f json"
+    "tr report generate /tmp/test_scan_alpine.json -o /tmp/test_report.json -f json"
 
 run_test "Generate Markdown report" \
-    "threat-radar report generate /tmp/test_scan_alpine.json -o /tmp/test_report.md -f markdown"
+    "tr report generate /tmp/test_scan_alpine.json -o /tmp/test_report.md -f markdown"
 
 run_test "Generate HTML report" \
-    "threat-radar report generate /tmp/test_scan_alpine.json -o /tmp/test_report.html -f html"
+    "tr report generate /tmp/test_scan_alpine.json -o /tmp/test_report.html -f html"
 
 run_test "Dashboard export" \
-    "threat-radar report dashboard-export /tmp/test_scan_alpine.json -o /tmp/test_dashboard.json"
+    "tr report dashboard-export /tmp/test_scan_alpine.json -o /tmp/test_dashboard.json"
 
 # ============================================================================
 # 7. FILE SYSTEM ACCESS
@@ -209,13 +209,13 @@ echo "=== 9. Multiple Image Format Tests ==="
 echo ""
 
 run_test "Scan lightweight image (busybox)" \
-    "threat-radar cve scan-image busybox:latest -o /tmp/test_busybox.json"
+    "tr cve scan-image busybox:latest -o /tmp/test_busybox.json"
 
 run_test "Generate SBOM for Python image" \
-    "threat-radar sbom docker python:3.11-alpine -o /tmp/test_python_sbom.json"
+    "tr sbom docker python:3.11-alpine -o /tmp/test_python_sbom.json"
 
 run_test "Scan nginx image" \
-    "threat-radar cve scan-image nginx:alpine -o /tmp/test_nginx.json"
+    "tr cve scan-image nginx:alpine -o /tmp/test_nginx.json"
 
 # ============================================================================
 # 10. ADVANCED OPERATIONS
@@ -224,16 +224,16 @@ echo "=== 10. Advanced Operations Tests ==="
 echo ""
 
 run_test "Generate SBOM with different format" \
-    "threat-radar sbom docker redis:alpine -o /tmp/test_redis.json"
+    "tr sbom docker redis:alpine -o /tmp/test_redis.json"
 
 run_test "Compare two SBOMs" \
-    "threat-radar sbom compare /app/sbom_storage/test_alpine.json /tmp/test_python_sbom.json"
+    "tr sbom compare /app/sbom_storage/test_alpine.json /tmp/test_python_sbom.json"
 
 run_test "Export SBOM to CSV" \
-    "threat-radar sbom export /app/sbom_storage/test_alpine.json -o /tmp/packages.csv -f csv"
+    "tr sbom export /app/sbom_storage/test_alpine.json -o /tmp/packages.csv -f csv"
 
 run_test "Build graph with auto-save" \
-    "threat-radar graph build /tmp/test_scan_alpine.json --auto-save"
+    "tr graph build /tmp/test_scan_alpine.json --auto-save"
 
 # ============================================================================
 # SUMMARY

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -298,8 +298,8 @@ open -a Docker
 pip3 install threat-radar
 
 # 5. Verify installation
-threat-radar --version
-threat-radar --help
+tr --version
+tr --help
 ```
 
 ### Complete Setup on Ubuntu 22.04
@@ -324,8 +324,8 @@ curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -
 pip3 install threat-radar
 
 # 7. Verify installation
-threat-radar --version
-threat-radar --help
+tr --version
+tr --help
 ```
 
 ### Complete Setup on Windows 10/11
@@ -348,8 +348,8 @@ scoop install grype syft
 pip install threat-radar
 
 # 6. Verify installation
-threat-radar --version
-threat-radar --help
+tr --version
+tr --help
 ```
 
 ---
@@ -391,8 +391,8 @@ LOCAL_MODEL_ENDPOINT=http://localhost:11434
 Update Grype's vulnerability database:
 
 ```bash
-threat-radar cve db-update
-threat-radar cve db-status
+tr cve db-update
+tr cve db-status
 ```
 
 ### 3. Ollama Setup (for local AI)
@@ -423,34 +423,34 @@ ollama list
 
 ```bash
 # Check CLI is accessible
-threat-radar --version
-tradar --version  # Shortened alias
+tr --version
+tr --version  # Shortened alias
 
 # View help
-threat-radar --help
-threat-radar cve --help
-threat-radar ai --help
+tr --help
+tr cve --help
+tr ai --help
 ```
 
 ### Test Basic Functionality
 
 ```bash
 # Test CVE scanning
-threat-radar cve scan-image alpine:3.18
+tr cve scan-image alpine:3.18
 
 # Test SBOM generation
-threat-radar sbom docker alpine:3.18 -o test-sbom.json
+tr sbom docker alpine:3.18 -o test-sbom.json
 
 # Test Docker integration
-threat-radar docker list-images
+tr docker list-images
 ```
 
 ### Test AI Features (if configured)
 
 ```bash
 # Scan and analyze
-threat-radar cve scan-image alpine:3.18 -o scan.json
-threat-radar ai analyze scan.json
+tr cve scan-image alpine:3.18 -o scan.json
+tr ai analyze scan.json
 ```
 
 ### Run Test Suite (for development installations)
@@ -475,7 +475,7 @@ pytest tests/test_ai_integration.py -v
 **Solution:**
 ```bash
 # Ensure pip installation directory is in PATH
-python3 -m pip show threat-radar  # Check install location
+python3 -m pip show tr  # Check install location
 
 # Add to PATH (Linux/macOS)
 export PATH="$HOME/.local/bin:$PATH"
@@ -579,7 +579,7 @@ brew upgrade syft  # macOS
 # Or reinstall: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh
 
 # Update vulnerability database
-threat-radar cve db-update
+tr cve db-update
 ```
 
 ---
@@ -632,6 +632,6 @@ docker image prune -a
 
 Next steps:
 1. Configure your API keys in `.env` (if using AI features)
-2. Update Grype database: `threat-radar cve db-update`
-3. Run your first scan: `threat-radar cve scan-image alpine:3.18`
+2. Update Grype database: `tr cve db-update`
+3. Run your first scan: `tr cve scan-image alpine:3.18`
 4. Explore examples: `cd examples && ls`

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -298,8 +298,8 @@ open -a Docker
 pip3 install threat-radar
 
 # 5. Verify installation
-tr --version
-tr --help
+tradar --version
+tradar --help
 ```
 
 ### Complete Setup on Ubuntu 22.04
@@ -324,8 +324,8 @@ curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -
 pip3 install threat-radar
 
 # 7. Verify installation
-tr --version
-tr --help
+tradar --version
+tradar --help
 ```
 
 ### Complete Setup on Windows 10/11
@@ -348,8 +348,8 @@ scoop install grype syft
 pip install threat-radar
 
 # 6. Verify installation
-tr --version
-tr --help
+tradar --version
+tradar --help
 ```
 
 ---
@@ -391,8 +391,8 @@ LOCAL_MODEL_ENDPOINT=http://localhost:11434
 Update Grype's vulnerability database:
 
 ```bash
-tr cve db-update
-tr cve db-status
+tradar cve db-update
+tradar cve db-status
 ```
 
 ### 3. Ollama Setup (for local AI)
@@ -423,34 +423,34 @@ ollama list
 
 ```bash
 # Check CLI is accessible
-tr --version
-tr --version  # Shortened alias
+tradar --version
+tradar --version  # Shortened alias
 
 # View help
-tr --help
-tr cve --help
-tr ai --help
+tradar --help
+tradar cve --help
+tradar ai --help
 ```
 
 ### Test Basic Functionality
 
 ```bash
 # Test CVE scanning
-tr cve scan-image alpine:3.18
+tradar cve scan-image alpine:3.18
 
 # Test SBOM generation
-tr sbom docker alpine:3.18 -o test-sbom.json
+tradar sbom docker alpine:3.18 -o test-sbom.json
 
 # Test Docker integration
-tr docker list-images
+tradar docker list-images
 ```
 
 ### Test AI Features (if configured)
 
 ```bash
 # Scan and analyze
-tr cve scan-image alpine:3.18 -o scan.json
-tr ai analyze scan.json
+tradar cve scan-image alpine:3.18 -o scan.json
+tradar ai analyze scan.json
 ```
 
 ### Run Test Suite (for development installations)
@@ -579,7 +579,7 @@ brew upgrade syft  # macOS
 # Or reinstall: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh
 
 # Update vulnerability database
-tr cve db-update
+tradar cve db-update
 ```
 
 ---
@@ -632,6 +632,6 @@ docker image prune -a
 
 Next steps:
 1. Configure your API keys in `.env` (if using AI features)
-2. Update Grype database: `tr cve db-update`
-3. Run your first scan: `tr cve scan-image alpine:3.18`
+2. Update Grype database: `tradar cve db-update`
+3. Run your first scan: `tradar cve scan-image alpine:3.18`
 4. Explore examples: `cd examples && ls`

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -120,8 +120,8 @@ python -m build
 pip install dist/threat_radar-0.1.0-py3-none-any.whl
 
 # Test CLI
-threat-radar --version
-threat-radar --help
+tr --version
+tr --help
 
 # Test imports
 python -c "from threat_radar import GrypeClient; print('Import successful')"
@@ -195,8 +195,8 @@ pip install --index-url https://test.pypi.org/simple/ --no-deps threat-radar
 pip install PyGithub python-dotenv typer docker openai tenacity
 
 # Test
-threat-radar --version
-threat-radar --help
+tr --version
+tr --help
 ```
 
 ---
@@ -251,7 +251,7 @@ source verify_env/bin/activate
 pip install threat-radar
 
 # Verify
-threat-radar --version
+tr --version
 python -c "from threat_radar import GrypeClient; print('Success!')"
 ```
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -120,8 +120,8 @@ python -m build
 pip install dist/threat_radar-0.1.0-py3-none-any.whl
 
 # Test CLI
-tr --version
-tr --help
+tradar --version
+tradar --help
 
 # Test imports
 python -c "from threat_radar import GrypeClient; print('Import successful')"
@@ -195,8 +195,8 @@ pip install --index-url https://test.pypi.org/simple/ --no-deps threat-radar
 pip install PyGithub python-dotenv typer docker openai tenacity
 
 # Test
-tr --version
-tr --help
+tradar --version
+tradar --help
 ```
 
 ---
@@ -251,7 +251,7 @@ source verify_env/bin/activate
 pip install threat-radar
 
 # Verify
-tr --version
+tradar --version
 python -c "from threat_radar import GrypeClient; print('Success!')"
 ```
 

--- a/docs/docker/DOCKER_INTERACTIVE.md
+++ b/docs/docker/DOCKER_INTERACTIVE.md
@@ -35,7 +35,7 @@ docker-compose run --rm --entrypoint /bin/bash threat-radar
 
 ## 📖 Inside the Interactive Shell
 
-Once inside the container, you have full access to all threat-radar commands:
+Once inside the container, you have full access to all tr commands:
 
 ```bash
 # You'll see the startup banner:
@@ -48,9 +48,9 @@ Syft Version: Application:   syft
 ...
 
 # Now you can run any command:
-threatradar@container:/app$ threat-radar --help
-threatradar@container:/app$ threat-radar cve scan-image alpine:3.18 --auto-save
-threatradar@container:/app$ threat-radar health check
+threatradar@container:/app$ tr --help
+threatradar@container:/app$ tr cve scan-image alpine:3.18 --auto-save
+threatradar@container:/app$ tr health check
 ```
 
 ---
@@ -64,9 +64,9 @@ threatradar@container:/app$ threat-radar health check
 make docker-shell
 
 # Inside container:
-$ threat-radar cve scan-image alpine:3.18 --auto-save
-$ threat-radar cve scan-image python:3.11 --auto-save
-$ threat-radar cve scan-image nginx:alpine --auto-save
+$ tr cve scan-image alpine:3.18 --auto-save
+$ tr cve scan-image python:3.11 --auto-save
+$ tr cve scan-image nginx:alpine --auto-save
 
 # Check results
 $ ls -lh storage/cve_storage/
@@ -92,24 +92,24 @@ docker run --rm -it \
 
 # Inside container - full workflow:
 $ # Step 1: Scan
-$ threat-radar cve scan-image myapp:latest --auto-save
+$ tr cve scan-image myapp:latest --auto-save
 
 $ # Step 2: Find the scan file
 $ SCAN_FILE=$(ls -t storage/cve_storage/myapp*.json | head -1)
 $ echo "Analyzing: $SCAN_FILE"
 
 $ # Step 3: AI analysis
-$ threat-radar ai analyze $SCAN_FILE --auto-save
+$ tr ai analyze $SCAN_FILE --auto-save
 
 $ # Step 4: Build graph
-$ threat-radar graph build $SCAN_FILE --auto-save
+$ tr graph build $SCAN_FILE --auto-save
 
 $ # Step 5: Query graph
 $ GRAPH_FILE=$(ls -t storage/graph_storage/*.graphml | head -1)
-$ threat-radar graph query $GRAPH_FILE --stats
+$ tr graph query $GRAPH_FILE --stats
 
 $ # Step 6: Find attack paths
-$ threat-radar graph attack-paths $GRAPH_FILE -o storage/attack-paths.json
+$ tr graph attack-paths $GRAPH_FILE -o storage/attack-paths.json
 
 $ # View results
 $ ls -lh storage/
@@ -123,9 +123,9 @@ $ exit
 make docker-shell
 
 # Test different severity filters
-$ threat-radar cve scan-image alpine:3.18 --severity CRITICAL -o /tmp/critical.json
-$ threat-radar cve scan-image alpine:3.18 --severity HIGH -o /tmp/high.json
-$ threat-radar cve scan-image alpine:3.18 --severity MEDIUM -o /tmp/medium.json
+$ tr cve scan-image alpine:3.18 --severity CRITICAL -o /tmp/critical.json
+$ tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/high.json
+$ tr cve scan-image alpine:3.18 --severity MEDIUM -o /tmp/medium.json
 
 # Compare results
 $ jq '.matches | length' /tmp/critical.json
@@ -133,12 +133,12 @@ $ jq '.matches | length' /tmp/high.json
 $ jq '.matches | length' /tmp/medium.json
 
 # Test SBOM generation
-$ threat-radar sbom docker python:3.11 -o /tmp/python-sbom.json
-$ threat-radar sbom read /tmp/python-sbom.json
+$ tr sbom docker python:3.11 -o /tmp/python-sbom.json
+$ tr sbom read /tmp/python-sbom.json
 
 # Test health checks
-$ threat-radar health check --verbose
-$ threat-radar health version
+$ tr health check --verbose
+$ tr health version
 
 $ exit
 ```
@@ -160,7 +160,7 @@ EOF
 # Scan all images
 $ while read image; do
     echo "Scanning $image..."
-    threat-radar cve scan-image $image --auto-save --cleanup
+    tr cve scan-image $image --auto-save --cleanup
   done < /tmp/images.txt
 
 # View all results
@@ -186,13 +186,13 @@ $ exit
 docker-compose up -d
 
 # Terminal 2: Interactive shell
-docker-compose exec threat-radar /bin/bash
+docker-compose exec tr /bin/bash
 
 # Terminal 3: Watch logs
 docker-compose logs -f threat-radar
 
 # In Terminal 2, run commands and watch logs in Terminal 3
-$ threat-radar cve scan-image alpine:3.18 --auto-save
+$ tr cve scan-image alpine:3.18 --auto-save
 ```
 
 ### 2. Python REPL Access
@@ -265,7 +265,7 @@ docker run -d -it \
 
 # Session 1: Connect and run scans
 docker exec -it tr-dev /bin/bash
-$ threat-radar cve scan-image alpine:3.18 --auto-save
+$ tr cve scan-image alpine:3.18 --auto-save
 
 # Session 2 (different terminal): Monitor
 docker exec -it tr-dev tail -f /app/logs/app.log
@@ -288,7 +288,7 @@ docker rm tr-dev
 make docker-shell
 
 # Check system status
-$ threat-radar health check --verbose
+$ tr health check --verbose
 
 # Test Docker connection
 $ docker ps
@@ -309,7 +309,7 @@ $ ls -la /app/cache/
 $ touch /app/storage/test.txt && rm /app/storage/test.txt && echo "Storage writable"
 
 # Run a test scan with verbose output
-$ threat-radar -vv cve scan-image alpine:3.18 -o /tmp/test-scan.json
+$ tr -vv cve scan-image alpine:3.18 -o /tmp/test-scan.json
 
 # Check the output
 $ cat /tmp/test-scan.json | jq '.matches | length'
@@ -332,7 +332,7 @@ docker run --rm -it \
 $ export LOG_LEVEL=DEBUG
 
 # Run problematic command
-$ threat-radar cve scan-image problematic-image:tag 2>&1 | tee /tmp/debug.log
+$ tr cve scan-image problematic-image:tag 2>&1 | tee /tmp/debug.log
 
 # Analyze the error
 $ cat /tmp/debug.log | grep -i error
@@ -418,8 +418,8 @@ $ exit
 
 1. **Use tab completion:**
    ```bash
-   $ threat-radar c<TAB>
-   $ threat-radar cve s<TAB>
+   $ tr c<TAB>
+   $ tr cve s<TAB>
    ```
 
 2. **History navigation:**
@@ -430,7 +430,7 @@ $ exit
 
 3. **Background jobs:**
    ```bash
-   $ threat-radar cve scan-image large-image:tag --auto-save &
+   $ tr cve scan-image large-image:tag --auto-save &
    $ jobs
    $ fg  # Bring back to foreground
    ```
@@ -467,13 +467,13 @@ $ exit
 make docker-shell
 
 # Experiment safely - container is ephemeral
-$ threat-radar --help | less
-$ threat-radar cve --help
-$ threat-radar ai --help
+$ tr --help | less
+$ tr cve --help
+$ tr ai --help
 
 # Try different options
-$ threat-radar cve scan-image alpine:3.18 --help
-$ threat-radar cve scan-image alpine:3.18 --severity HIGH -o /tmp/test.json
+$ tr cve scan-image alpine:3.18 --help
+$ tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/test.json
 $ cat /tmp/test.json | jq '.matches | length'
 
 # Everything is cleaned up on exit
@@ -488,19 +488,19 @@ make docker-shell
 
 # Show capabilities step by step
 $ echo "Step 1: Health Check"
-$ threat-radar health check --verbose
+$ tr health check --verbose
 
 $ echo -e "\nStep 2: Scan an image"
-$ threat-radar cve scan-image alpine:3.18 --auto-save
+$ tr cve scan-image alpine:3.18 --auto-save
 
 $ echo -e "\nStep 3: View results"
 $ ls -lh storage/cve_storage/
 
 $ echo -e "\nStep 4: Generate SBOM"
-$ threat-radar sbom docker python:3.11 -o /tmp/python-sbom.json
+$ tr sbom docker python:3.11 -o /tmp/python-sbom.json
 
 $ echo -e "\nStep 5: Analyze SBOM"
-$ threat-radar sbom stats /tmp/python-sbom.json
+$ tr sbom stats /tmp/python-sbom.json
 
 $ exit
 ```
@@ -520,9 +520,9 @@ $ exit
 
 ```bash
 # Inside the container:
-$ threat-radar --help                    # Main help
-$ threat-radar <command> --help          # Command-specific help
-$ threat-radar health check --verbose    # System status
+$ tr --help                    # Main help
+$ tr <command> --help          # Command-specific help
+$ tr health check --verbose    # System status
 $ grype --help                           # Grype help
 $ syft --help                            # Syft help
 ```

--- a/docs/docker/DOCKER_INTERACTIVE.md
+++ b/docs/docker/DOCKER_INTERACTIVE.md
@@ -35,7 +35,7 @@ docker-compose run --rm --entrypoint /bin/bash threat-radar
 
 ## 📖 Inside the Interactive Shell
 
-Once inside the container, you have full access to all tr commands:
+Once inside the container, you have full access to all tradar commands:
 
 ```bash
 # You'll see the startup banner:
@@ -48,9 +48,9 @@ Syft Version: Application:   syft
 ...
 
 # Now you can run any command:
-threatradar@container:/app$ tr --help
-threatradar@container:/app$ tr cve scan-image alpine:3.18 --auto-save
-threatradar@container:/app$ tr health check
+threatradar@container:/app$ tradar --help
+threatradar@container:/app$ tradar cve scan-image alpine:3.18 --auto-save
+threatradar@container:/app$ tradar health check
 ```
 
 ---
@@ -64,9 +64,9 @@ threatradar@container:/app$ tr health check
 make docker-shell
 
 # Inside container:
-$ tr cve scan-image alpine:3.18 --auto-save
-$ tr cve scan-image python:3.11 --auto-save
-$ tr cve scan-image nginx:alpine --auto-save
+$ tradar cve scan-image alpine:3.18 --auto-save
+$ tradar cve scan-image python:3.11 --auto-save
+$ tradar cve scan-image nginx:alpine --auto-save
 
 # Check results
 $ ls -lh storage/cve_storage/
@@ -92,24 +92,24 @@ docker run --rm -it \
 
 # Inside container - full workflow:
 $ # Step 1: Scan
-$ tr cve scan-image myapp:latest --auto-save
+$ tradar cve scan-image myapp:latest --auto-save
 
 $ # Step 2: Find the scan file
 $ SCAN_FILE=$(ls -t storage/cve_storage/myapp*.json | head -1)
 $ echo "Analyzing: $SCAN_FILE"
 
 $ # Step 3: AI analysis
-$ tr ai analyze $SCAN_FILE --auto-save
+$ tradar ai analyze $SCAN_FILE --auto-save
 
 $ # Step 4: Build graph
-$ tr graph build $SCAN_FILE --auto-save
+$ tradar graph build $SCAN_FILE --auto-save
 
 $ # Step 5: Query graph
 $ GRAPH_FILE=$(ls -t storage/graph_storage/*.graphml | head -1)
-$ tr graph query $GRAPH_FILE --stats
+$ tradar graph query $GRAPH_FILE --stats
 
 $ # Step 6: Find attack paths
-$ tr graph attack-paths $GRAPH_FILE -o storage/attack-paths.json
+$ tradar graph attack-paths $GRAPH_FILE -o storage/attack-paths.json
 
 $ # View results
 $ ls -lh storage/
@@ -123,9 +123,9 @@ $ exit
 make docker-shell
 
 # Test different severity filters
-$ tr cve scan-image alpine:3.18 --severity CRITICAL -o /tmp/critical.json
-$ tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/high.json
-$ tr cve scan-image alpine:3.18 --severity MEDIUM -o /tmp/medium.json
+$ tradar cve scan-image alpine:3.18 --severity CRITICAL -o /tmp/critical.json
+$ tradar cve scan-image alpine:3.18 --severity HIGH -o /tmp/high.json
+$ tradar cve scan-image alpine:3.18 --severity MEDIUM -o /tmp/medium.json
 
 # Compare results
 $ jq '.matches | length' /tmp/critical.json
@@ -133,12 +133,12 @@ $ jq '.matches | length' /tmp/high.json
 $ jq '.matches | length' /tmp/medium.json
 
 # Test SBOM generation
-$ tr sbom docker python:3.11 -o /tmp/python-sbom.json
-$ tr sbom read /tmp/python-sbom.json
+$ tradar sbom docker python:3.11 -o /tmp/python-sbom.json
+$ tradar sbom read /tmp/python-sbom.json
 
 # Test health checks
-$ tr health check --verbose
-$ tr health version
+$ tradar health check --verbose
+$ tradar health version
 
 $ exit
 ```
@@ -160,7 +160,7 @@ EOF
 # Scan all images
 $ while read image; do
     echo "Scanning $image..."
-    tr cve scan-image $image --auto-save --cleanup
+    tradar cve scan-image $image --auto-save --cleanup
   done < /tmp/images.txt
 
 # View all results
@@ -192,7 +192,7 @@ docker-compose exec tr /bin/bash
 docker-compose logs -f threat-radar
 
 # In Terminal 2, run commands and watch logs in Terminal 3
-$ tr cve scan-image alpine:3.18 --auto-save
+$ tradar cve scan-image alpine:3.18 --auto-save
 ```
 
 ### 2. Python REPL Access
@@ -265,7 +265,7 @@ docker run -d -it \
 
 # Session 1: Connect and run scans
 docker exec -it tr-dev /bin/bash
-$ tr cve scan-image alpine:3.18 --auto-save
+$ tradar cve scan-image alpine:3.18 --auto-save
 
 # Session 2 (different terminal): Monitor
 docker exec -it tr-dev tail -f /app/logs/app.log
@@ -288,7 +288,7 @@ docker rm tr-dev
 make docker-shell
 
 # Check system status
-$ tr health check --verbose
+$ tradar health check --verbose
 
 # Test Docker connection
 $ docker ps
@@ -309,7 +309,7 @@ $ ls -la /app/cache/
 $ touch /app/storage/test.txt && rm /app/storage/test.txt && echo "Storage writable"
 
 # Run a test scan with verbose output
-$ tr -vv cve scan-image alpine:3.18 -o /tmp/test-scan.json
+$ tradar -vv cve scan-image alpine:3.18 -o /tmp/test-scan.json
 
 # Check the output
 $ cat /tmp/test-scan.json | jq '.matches | length'
@@ -332,7 +332,7 @@ docker run --rm -it \
 $ export LOG_LEVEL=DEBUG
 
 # Run problematic command
-$ tr cve scan-image problematic-image:tag 2>&1 | tee /tmp/debug.log
+$ tradar cve scan-image problematic-image:tag 2>&1 | tee /tmp/debug.log
 
 # Analyze the error
 $ cat /tmp/debug.log | grep -i error
@@ -418,8 +418,8 @@ $ exit
 
 1. **Use tab completion:**
    ```bash
-   $ tr c<TAB>
-   $ tr cve s<TAB>
+   $ tradar c<TAB>
+   $ tradar cve s<TAB>
    ```
 
 2. **History navigation:**
@@ -430,7 +430,7 @@ $ exit
 
 3. **Background jobs:**
    ```bash
-   $ tr cve scan-image large-image:tag --auto-save &
+   $ tradar cve scan-image large-image:tag --auto-save &
    $ jobs
    $ fg  # Bring back to foreground
    ```
@@ -467,13 +467,13 @@ $ exit
 make docker-shell
 
 # Experiment safely - container is ephemeral
-$ tr --help | less
-$ tr cve --help
-$ tr ai --help
+$ tradar --help | less
+$ tradar cve --help
+$ tradar ai --help
 
 # Try different options
-$ tr cve scan-image alpine:3.18 --help
-$ tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/test.json
+$ tradar cve scan-image alpine:3.18 --help
+$ tradar cve scan-image alpine:3.18 --severity HIGH -o /tmp/test.json
 $ cat /tmp/test.json | jq '.matches | length'
 
 # Everything is cleaned up on exit
@@ -488,19 +488,19 @@ make docker-shell
 
 # Show capabilities step by step
 $ echo "Step 1: Health Check"
-$ tr health check --verbose
+$ tradar health check --verbose
 
 $ echo -e "\nStep 2: Scan an image"
-$ tr cve scan-image alpine:3.18 --auto-save
+$ tradar cve scan-image alpine:3.18 --auto-save
 
 $ echo -e "\nStep 3: View results"
 $ ls -lh storage/cve_storage/
 
 $ echo -e "\nStep 4: Generate SBOM"
-$ tr sbom docker python:3.11 -o /tmp/python-sbom.json
+$ tradar sbom docker python:3.11 -o /tmp/python-sbom.json
 
 $ echo -e "\nStep 5: Analyze SBOM"
-$ tr sbom stats /tmp/python-sbom.json
+$ tradar sbom stats /tmp/python-sbom.json
 
 $ exit
 ```
@@ -520,9 +520,9 @@ $ exit
 
 ```bash
 # Inside the container:
-$ tr --help                    # Main help
-$ tr <command> --help          # Command-specific help
-$ tr health check --verbose    # System status
+$ tradar --help                    # Main help
+$ tradar <command> --help          # Command-specific help
+$ tradar health check --verbose    # System status
 $ grype --help                           # Grype help
 $ syft --help                            # Syft help
 ```

--- a/docs/docker/DOCKER_LOCAL_SCANNING.md
+++ b/docs/docker/DOCKER_LOCAL_SCANNING.md
@@ -13,8 +13,8 @@ Guide for scanning local projects and directories using Threat Radar Docker cont
 make docker-shell-project PROJECT=/path/to/your/project
 
 # Inside container:
-$ tr sbom generate /workspace -o /app/sbom_storage/my-project.json
-$ tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+$ tradar sbom generate /workspace -o /app/sbom_storage/my-project.json
+$ tradar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 $ exit
 ```
 
@@ -29,7 +29,7 @@ docker run --rm -it \
   threat-radar:latest
 
 # Inside container:
-$ tr sbom generate /workspace -o /app/sbom_storage/project-sbom.json
+$ tradar sbom generate /workspace -o /app/sbom_storage/project-sbom.json
 ```
 
 ---
@@ -44,16 +44,16 @@ make docker-shell-project PROJECT=~/my-nodejs-app
 
 # Inside container:
 # 2. Generate SBOM
-$ tr sbom generate /workspace -o /app/sbom_storage/nodejs-app.json
+$ tradar sbom generate /workspace -o /app/sbom_storage/nodejs-app.json
 
 # 3. View the SBOM
-$ tr sbom read /app/sbom_storage/nodejs-app.json
+$ tradar sbom read /app/sbom_storage/nodejs-app.json
 
 # 4. Get package statistics
-$ tr sbom stats /app/sbom_storage/nodejs-app.json
+$ tradar sbom stats /app/sbom_storage/nodejs-app.json
 
 # 5. Scan for vulnerabilities
-$ tr cve scan-sbom /app/sbom_storage/nodejs-app.json --auto-save
+$ tradar cve scan-sbom /app/sbom_storage/nodejs-app.json --auto-save
 
 # 6. View results
 $ ls -lh /app/storage/cve_storage/
@@ -73,9 +73,9 @@ cat storage/cve_storage/nodejs-app_sbom_*.json | jq '.matches | length'
 make docker-shell-project PROJECT=~/my-python-app
 
 # Inside container:
-$ tr sbom generate /workspace -o /app/sbom_storage/python-app.json
-$ tr sbom search /app/sbom_storage/python-app.json django
-$ tr cve scan-sbom /app/sbom_storage/python-app.json --severity HIGH --auto-save
+$ tradar sbom generate /workspace -o /app/sbom_storage/python-app.json
+$ tradar sbom search /app/sbom_storage/python-app.json django
+$ tradar cve scan-sbom /app/sbom_storage/python-app.json --severity HIGH --auto-save
 $ exit
 ```
 
@@ -86,9 +86,9 @@ $ exit
 make docker-shell-project PROJECT=~/my-go-app
 
 # Inside container:
-$ tr sbom generate /workspace -o /app/sbom_storage/go-app.json
-$ tr sbom components /app/sbom_storage/go-app.json --language go
-$ tr cve scan-sbom /app/sbom_storage/go-app.json --auto-save
+$ tradar sbom generate /workspace -o /app/sbom_storage/go-app.json
+$ tradar sbom components /app/sbom_storage/go-app.json --language go
+$ tradar cve scan-sbom /app/sbom_storage/go-app.json --auto-save
 $ exit
 ```
 
@@ -119,8 +119,8 @@ for project in "${PROJECTS[@]}"; do
     -v "$project:/workspace:ro" \
     threat-radar:latest \
     sh -c "
-      tr sbom generate /workspace -o /app/sbom_storage/${name}.json && \
-      tr cve scan-sbom /app/sbom_storage/${name}.json --auto-save
+      tradar sbom generate /workspace -o /app/sbom_storage/${name}.json && \
+      tradar cve scan-sbom /app/sbom_storage/${name}.json --auto-save
     "
 done
 
@@ -146,12 +146,12 @@ docker run --rm -it \
 $ for project in /projects/*; do
     name=$(basename "$project")
     echo "Processing: $name"
-    tr sbom generate "$project" -o "/app/sbom_storage/${name}.json"
-    tr cve scan-sbom "/app/sbom_storage/${name}.json" --auto-save
+    tradar sbom generate "$project" -o "/app/sbom_storage/${name}.json"
+    tradar cve scan-sbom "/app/sbom_storage/${name}.json" --auto-save
   done
 
 # Compare SBOMs
-$ tr sbom compare \
+$ tradar sbom compare \
     /app/sbom_storage/frontend.json \
     /app/sbom_storage/backend.json
 
@@ -168,7 +168,7 @@ $ exit
 make docker-shell-project PROJECT=~/my-app
 
 # Inside container - scan only src/
-$ tr sbom generate /workspace/src -o /app/sbom_storage/src-only.json
+$ tradar sbom generate /workspace/src -o /app/sbom_storage/src-only.json
 ```
 
 ### Scan Multiple Subdirectories
@@ -177,9 +177,9 @@ $ tr sbom generate /workspace/src -o /app/sbom_storage/src-only.json
 make docker-shell-project PROJECT=~/my-monorepo
 
 # Inside container:
-$ tr sbom generate /workspace/packages/frontend -o /app/sbom_storage/frontend.json
-$ tr sbom generate /workspace/packages/backend -o /app/sbom_storage/backend.json
-$ tr sbom generate /workspace/packages/shared -o /app/sbom_storage/shared.json
+$ tradar sbom generate /workspace/packages/frontend -o /app/sbom_storage/frontend.json
+$ tradar sbom generate /workspace/packages/backend -o /app/sbom_storage/backend.json
+$ tradar sbom generate /workspace/packages/shared -o /app/sbom_storage/shared.json
 ```
 
 ---
@@ -207,30 +207,30 @@ docker run --rm -it \
   threat-radar:latest << COMMANDS
 
 echo "Step 1: Generating SBOM..."
-tr sbom generate /workspace -o /app/sbom_storage/${PROJECT_NAME}.json
+tradar sbom generate /workspace -o /app/sbom_storage/${PROJECT_NAME}.json
 
 echo "Step 2: SBOM Statistics..."
-tr sbom stats /app/sbom_storage/${PROJECT_NAME}.json
+tradar sbom stats /app/sbom_storage/${PROJECT_NAME}.json
 
 echo "Step 3: Scanning for vulnerabilities..."
-tr cve scan-sbom /app/sbom_storage/${PROJECT_NAME}.json --auto-save
+tradar cve scan-sbom /app/sbom_storage/${PROJECT_NAME}.json --auto-save
 
 echo "Step 4: Building vulnerability graph..."
 SCAN_FILE=\$(ls -t /app/storage/cve_storage/${PROJECT_NAME}*.json | head -1)
-tr graph build "\$SCAN_FILE" --auto-save
+tradar graph build "\$SCAN_FILE" --auto-save
 
 echo "Step 5: Querying graph..."
 GRAPH_FILE=\$(ls -t /app/storage/graph_storage/*.graphml | head -1)
-tr graph query "\$GRAPH_FILE" --stats
+tradar graph query "\$GRAPH_FILE" --stats
 
 echo "Step 6: Finding attack paths..."
-tr graph attack-paths "\$GRAPH_FILE" -o /app/storage/attack-paths.json
+tradar graph attack-paths "\$GRAPH_FILE" -o /app/storage/attack-paths.json
 
 # If AI is configured
 if [ -n "\$OPENAI_API_KEY" ]; then
   echo "Step 7: AI Analysis..."
-  tr ai analyze "\$SCAN_FILE" --auto-save
-  tr ai prioritize "\$SCAN_FILE" --auto-save
+  tradar ai analyze "\$SCAN_FILE" --auto-save
+  tradar ai prioritize "\$SCAN_FILE" --auto-save
 fi
 
 echo ""
@@ -279,7 +279,7 @@ docker run --rm -it \
   threat-radar:latest
 
 # Inside:
-$ tr sbom generate /workspace -o /app/sbom_storage/current-dir.json
+$ tradar sbom generate /workspace -o /app/sbom_storage/current-dir.json
 ```
 
 ### 3. Use Absolute Paths
@@ -321,7 +321,7 @@ Mount cache directory to speed up repeated scans:
 
 **Problem:**
 ```bash
-$ tr sbom generate /workspace
+$ tradar sbom generate /workspace
 Error: directory not found
 ```
 
@@ -340,7 +340,7 @@ make docker-shell-project PROJECT=/correct/path/to/project
 
 **Problem:**
 ```bash
-$ tr sbom generate /workspace -o /workspace/sbom.json
+$ tradar sbom generate /workspace -o /workspace/sbom.json
 Error: Permission denied
 ```
 
@@ -348,17 +348,17 @@ Error: Permission denied
 Output to the container's storage (not the read-only mounted directory):
 ```bash
 # ✅ Correct - output to /app/sbom_storage
-$ tr sbom generate /workspace -o /app/sbom_storage/project.json
+$ tradar sbom generate /workspace -o /app/sbom_storage/project.json
 
 # ❌ Wrong - trying to write to read-only mount
-$ tr sbom generate /workspace -o /workspace/sbom.json
+$ tradar sbom generate /workspace -o /workspace/sbom.json
 ```
 
 ### Issue: No Packages Found
 
 **Problem:**
 ```bash
-$ tr sbom generate /workspace
+$ tradar sbom generate /workspace
 Warning: No packages found
 ```
 
@@ -369,8 +369,8 @@ Make sure you're scanning the right directory:
 $ ls -la /workspace
 
 # Try scanning subdirectories
-$ tr sbom generate /workspace/src
-$ tr sbom generate /workspace/packages/myapp
+$ tradar sbom generate /workspace/src
+$ tradar sbom generate /workspace/packages/myapp
 ```
 
 ---
@@ -399,7 +399,7 @@ jobs:
             -v $(pwd):/workspace:ro \
             -v $(pwd)/results:/app/sbom_storage \
             threat-radar:latest \
-            tr sbom generate /workspace -o /app/sbom_storage/sbom.json
+            tradar sbom generate /workspace -o /app/sbom_storage/sbom.json
 
       - name: Scan SBOM
         run: |
@@ -407,7 +407,7 @@ jobs:
             -v $(pwd)/results:/app/sbom_storage \
             -v $(pwd)/results:/app/storage \
             threat-radar:latest \
-            tr cve scan-sbom /app/sbom_storage/sbom.json \
+            tradar cve scan-sbom /app/sbom_storage/sbom.json \
               --fail-on HIGH --auto-save
 
       - name: Upload Results
@@ -431,13 +431,13 @@ security-scan:
         -v $(pwd):/workspace:ro \
         -v $(pwd)/results:/app/sbom_storage \
         threat-radar:latest \
-        tr sbom generate /workspace -o /app/sbom_storage/sbom.json
+        tradar sbom generate /workspace -o /app/sbom_storage/sbom.json
     - |
       docker run --rm \
         -v $(pwd)/results:/app/sbom_storage \
         -v $(pwd)/results:/app/storage \
         threat-radar:latest \
-        tr cve scan-sbom /app/sbom_storage/sbom.json --auto-save
+        tradar cve scan-sbom /app/sbom_storage/sbom.json --auto-save
   artifacts:
     paths:
       - results/
@@ -461,7 +461,7 @@ security-scan:
 2. ✅ Always use `:ro` (read-only) for safety
 3. ✅ Output results to `/app/sbom_storage` or `/app/storage`
 4. ✅ Use `make docker-shell-project PROJECT=/path` for convenience
-5. ✅ Scan the mounted directory with `tr sbom generate /workspace`
+5. ✅ Scan the mounted directory with `tradar sbom generate /workspace`
 
 ---
 

--- a/docs/docker/DOCKER_LOCAL_SCANNING.md
+++ b/docs/docker/DOCKER_LOCAL_SCANNING.md
@@ -13,8 +13,8 @@ Guide for scanning local projects and directories using Threat Radar Docker cont
 make docker-shell-project PROJECT=/path/to/your/project
 
 # Inside container:
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/my-project.json
-$ threat-radar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+$ tr sbom generate /workspace -o /app/sbom_storage/my-project.json
+$ tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 $ exit
 ```
 
@@ -29,7 +29,7 @@ docker run --rm -it \
   threat-radar:latest
 
 # Inside container:
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/project-sbom.json
+$ tr sbom generate /workspace -o /app/sbom_storage/project-sbom.json
 ```
 
 ---
@@ -44,16 +44,16 @@ make docker-shell-project PROJECT=~/my-nodejs-app
 
 # Inside container:
 # 2. Generate SBOM
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/nodejs-app.json
+$ tr sbom generate /workspace -o /app/sbom_storage/nodejs-app.json
 
 # 3. View the SBOM
-$ threat-radar sbom read /app/sbom_storage/nodejs-app.json
+$ tr sbom read /app/sbom_storage/nodejs-app.json
 
 # 4. Get package statistics
-$ threat-radar sbom stats /app/sbom_storage/nodejs-app.json
+$ tr sbom stats /app/sbom_storage/nodejs-app.json
 
 # 5. Scan for vulnerabilities
-$ threat-radar cve scan-sbom /app/sbom_storage/nodejs-app.json --auto-save
+$ tr cve scan-sbom /app/sbom_storage/nodejs-app.json --auto-save
 
 # 6. View results
 $ ls -lh /app/storage/cve_storage/
@@ -73,9 +73,9 @@ cat storage/cve_storage/nodejs-app_sbom_*.json | jq '.matches | length'
 make docker-shell-project PROJECT=~/my-python-app
 
 # Inside container:
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/python-app.json
-$ threat-radar sbom search /app/sbom_storage/python-app.json django
-$ threat-radar cve scan-sbom /app/sbom_storage/python-app.json --severity HIGH --auto-save
+$ tr sbom generate /workspace -o /app/sbom_storage/python-app.json
+$ tr sbom search /app/sbom_storage/python-app.json django
+$ tr cve scan-sbom /app/sbom_storage/python-app.json --severity HIGH --auto-save
 $ exit
 ```
 
@@ -86,9 +86,9 @@ $ exit
 make docker-shell-project PROJECT=~/my-go-app
 
 # Inside container:
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/go-app.json
-$ threat-radar sbom components /app/sbom_storage/go-app.json --language go
-$ threat-radar cve scan-sbom /app/sbom_storage/go-app.json --auto-save
+$ tr sbom generate /workspace -o /app/sbom_storage/go-app.json
+$ tr sbom components /app/sbom_storage/go-app.json --language go
+$ tr cve scan-sbom /app/sbom_storage/go-app.json --auto-save
 $ exit
 ```
 
@@ -119,8 +119,8 @@ for project in "${PROJECTS[@]}"; do
     -v "$project:/workspace:ro" \
     threat-radar:latest \
     sh -c "
-      threat-radar sbom generate /workspace -o /app/sbom_storage/${name}.json && \
-      threat-radar cve scan-sbom /app/sbom_storage/${name}.json --auto-save
+      tr sbom generate /workspace -o /app/sbom_storage/${name}.json && \
+      tr cve scan-sbom /app/sbom_storage/${name}.json --auto-save
     "
 done
 
@@ -146,12 +146,12 @@ docker run --rm -it \
 $ for project in /projects/*; do
     name=$(basename "$project")
     echo "Processing: $name"
-    threat-radar sbom generate "$project" -o "/app/sbom_storage/${name}.json"
-    threat-radar cve scan-sbom "/app/sbom_storage/${name}.json" --auto-save
+    tr sbom generate "$project" -o "/app/sbom_storage/${name}.json"
+    tr cve scan-sbom "/app/sbom_storage/${name}.json" --auto-save
   done
 
 # Compare SBOMs
-$ threat-radar sbom compare \
+$ tr sbom compare \
     /app/sbom_storage/frontend.json \
     /app/sbom_storage/backend.json
 
@@ -168,7 +168,7 @@ $ exit
 make docker-shell-project PROJECT=~/my-app
 
 # Inside container - scan only src/
-$ threat-radar sbom generate /workspace/src -o /app/sbom_storage/src-only.json
+$ tr sbom generate /workspace/src -o /app/sbom_storage/src-only.json
 ```
 
 ### Scan Multiple Subdirectories
@@ -177,9 +177,9 @@ $ threat-radar sbom generate /workspace/src -o /app/sbom_storage/src-only.json
 make docker-shell-project PROJECT=~/my-monorepo
 
 # Inside container:
-$ threat-radar sbom generate /workspace/packages/frontend -o /app/sbom_storage/frontend.json
-$ threat-radar sbom generate /workspace/packages/backend -o /app/sbom_storage/backend.json
-$ threat-radar sbom generate /workspace/packages/shared -o /app/sbom_storage/shared.json
+$ tr sbom generate /workspace/packages/frontend -o /app/sbom_storage/frontend.json
+$ tr sbom generate /workspace/packages/backend -o /app/sbom_storage/backend.json
+$ tr sbom generate /workspace/packages/shared -o /app/sbom_storage/shared.json
 ```
 
 ---
@@ -207,30 +207,30 @@ docker run --rm -it \
   threat-radar:latest << COMMANDS
 
 echo "Step 1: Generating SBOM..."
-threat-radar sbom generate /workspace -o /app/sbom_storage/${PROJECT_NAME}.json
+tr sbom generate /workspace -o /app/sbom_storage/${PROJECT_NAME}.json
 
 echo "Step 2: SBOM Statistics..."
-threat-radar sbom stats /app/sbom_storage/${PROJECT_NAME}.json
+tr sbom stats /app/sbom_storage/${PROJECT_NAME}.json
 
 echo "Step 3: Scanning for vulnerabilities..."
-threat-radar cve scan-sbom /app/sbom_storage/${PROJECT_NAME}.json --auto-save
+tr cve scan-sbom /app/sbom_storage/${PROJECT_NAME}.json --auto-save
 
 echo "Step 4: Building vulnerability graph..."
 SCAN_FILE=\$(ls -t /app/storage/cve_storage/${PROJECT_NAME}*.json | head -1)
-threat-radar graph build "\$SCAN_FILE" --auto-save
+tr graph build "\$SCAN_FILE" --auto-save
 
 echo "Step 5: Querying graph..."
 GRAPH_FILE=\$(ls -t /app/storage/graph_storage/*.graphml | head -1)
-threat-radar graph query "\$GRAPH_FILE" --stats
+tr graph query "\$GRAPH_FILE" --stats
 
 echo "Step 6: Finding attack paths..."
-threat-radar graph attack-paths "\$GRAPH_FILE" -o /app/storage/attack-paths.json
+tr graph attack-paths "\$GRAPH_FILE" -o /app/storage/attack-paths.json
 
 # If AI is configured
 if [ -n "\$OPENAI_API_KEY" ]; then
   echo "Step 7: AI Analysis..."
-  threat-radar ai analyze "\$SCAN_FILE" --auto-save
-  threat-radar ai prioritize "\$SCAN_FILE" --auto-save
+  tr ai analyze "\$SCAN_FILE" --auto-save
+  tr ai prioritize "\$SCAN_FILE" --auto-save
 fi
 
 echo ""
@@ -279,7 +279,7 @@ docker run --rm -it \
   threat-radar:latest
 
 # Inside:
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/current-dir.json
+$ tr sbom generate /workspace -o /app/sbom_storage/current-dir.json
 ```
 
 ### 3. Use Absolute Paths
@@ -321,7 +321,7 @@ Mount cache directory to speed up repeated scans:
 
 **Problem:**
 ```bash
-$ threat-radar sbom generate /workspace
+$ tr sbom generate /workspace
 Error: directory not found
 ```
 
@@ -340,7 +340,7 @@ make docker-shell-project PROJECT=/correct/path/to/project
 
 **Problem:**
 ```bash
-$ threat-radar sbom generate /workspace -o /workspace/sbom.json
+$ tr sbom generate /workspace -o /workspace/sbom.json
 Error: Permission denied
 ```
 
@@ -348,17 +348,17 @@ Error: Permission denied
 Output to the container's storage (not the read-only mounted directory):
 ```bash
 # ✅ Correct - output to /app/sbom_storage
-$ threat-radar sbom generate /workspace -o /app/sbom_storage/project.json
+$ tr sbom generate /workspace -o /app/sbom_storage/project.json
 
 # ❌ Wrong - trying to write to read-only mount
-$ threat-radar sbom generate /workspace -o /workspace/sbom.json
+$ tr sbom generate /workspace -o /workspace/sbom.json
 ```
 
 ### Issue: No Packages Found
 
 **Problem:**
 ```bash
-$ threat-radar sbom generate /workspace
+$ tr sbom generate /workspace
 Warning: No packages found
 ```
 
@@ -369,8 +369,8 @@ Make sure you're scanning the right directory:
 $ ls -la /workspace
 
 # Try scanning subdirectories
-$ threat-radar sbom generate /workspace/src
-$ threat-radar sbom generate /workspace/packages/myapp
+$ tr sbom generate /workspace/src
+$ tr sbom generate /workspace/packages/myapp
 ```
 
 ---
@@ -399,7 +399,7 @@ jobs:
             -v $(pwd):/workspace:ro \
             -v $(pwd)/results:/app/sbom_storage \
             threat-radar:latest \
-            threat-radar sbom generate /workspace -o /app/sbom_storage/sbom.json
+            tr sbom generate /workspace -o /app/sbom_storage/sbom.json
 
       - name: Scan SBOM
         run: |
@@ -407,7 +407,7 @@ jobs:
             -v $(pwd)/results:/app/sbom_storage \
             -v $(pwd)/results:/app/storage \
             threat-radar:latest \
-            threat-radar cve scan-sbom /app/sbom_storage/sbom.json \
+            tr cve scan-sbom /app/sbom_storage/sbom.json \
               --fail-on HIGH --auto-save
 
       - name: Upload Results
@@ -431,13 +431,13 @@ security-scan:
         -v $(pwd):/workspace:ro \
         -v $(pwd)/results:/app/sbom_storage \
         threat-radar:latest \
-        threat-radar sbom generate /workspace -o /app/sbom_storage/sbom.json
+        tr sbom generate /workspace -o /app/sbom_storage/sbom.json
     - |
       docker run --rm \
         -v $(pwd)/results:/app/sbom_storage \
         -v $(pwd)/results:/app/storage \
         threat-radar:latest \
-        threat-radar cve scan-sbom /app/sbom_storage/sbom.json --auto-save
+        tr cve scan-sbom /app/sbom_storage/sbom.json --auto-save
   artifacts:
     paths:
       - results/
@@ -461,7 +461,7 @@ security-scan:
 2. ✅ Always use `:ro` (read-only) for safety
 3. ✅ Output results to `/app/sbom_storage` or `/app/storage`
 4. ✅ Use `make docker-shell-project PROJECT=/path` for convenience
-5. ✅ Scan the mounted directory with `threat-radar sbom generate /workspace`
+5. ✅ Scan the mounted directory with `tr sbom generate /workspace`
 
 ---
 

--- a/docs/docker/TESTING.md
+++ b/docs/docker/TESTING.md
@@ -25,22 +25,22 @@ cat /app/quick-test.sh
 
 ```bash
 # Show help
-threat-radar --help
+tr --help
 
 # Version info
-threat-radar --version
+tr --version
 
 # Health ping (quick)
-threat-radar health ping
+tr health ping
 
 # Full health check
-threat-radar health check
+tr health check
 
 # Verbose health check
-threat-radar health check --verbose
+tr health check --verbose
 
 # Show version details
-threat-radar health version
+tr health version
 ```
 
 **Expected Results:**
@@ -77,11 +77,11 @@ syft version
 
 #### Test Small Image (Alpine)
 ```bash
-threat-radar sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
+tr sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
 
 # Verify output
 ls -lh /app/sbom_storage/alpine.json
-threat-radar sbom read /app/sbom_storage/alpine.json
+tr sbom read /app/sbom_storage/alpine.json
 ```
 
 **Expected Results:**
@@ -91,10 +91,10 @@ threat-radar sbom read /app/sbom_storage/alpine.json
 
 #### Test Medium Image (Python)
 ```bash
-threat-radar sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
+tr sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
 
 # View stats
-threat-radar sbom stats /app/sbom_storage/python.json
+tr sbom stats /app/sbom_storage/python.json
 ```
 
 **Expected Results:**
@@ -104,7 +104,7 @@ threat-radar sbom stats /app/sbom_storage/python.json
 
 #### Test Large Image (Full Python)
 ```bash
-threat-radar sbom docker python:3.11 -o /app/sbom_storage/python-full.json
+tr sbom docker python:3.11 -o /app/sbom_storage/python-full.json
 
 # Compare sizes
 ls -lh /app/sbom_storage/python*.json
@@ -121,13 +121,13 @@ ls -lh /app/sbom_storage/python*.json
 #### Scan Docker Image Directly
 ```bash
 # Basic scan
-threat-radar cve scan-image alpine:3.18 -o /tmp/scan-alpine.json
+tr cve scan-image alpine:3.18 -o /tmp/scan-alpine.json
 
 # With severity filter
-threat-radar cve scan-image alpine:3.18 --severity HIGH -o /tmp/scan-high.json
+tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/scan-high.json
 
 # With auto-save
-threat-radar cve scan-image busybox:latest --auto-save
+tr cve scan-image busybox:latest --auto-save
 ```
 
 **Expected Results:**
@@ -139,10 +139,10 @@ threat-radar cve scan-image busybox:latest --auto-save
 #### Scan SBOM File
 ```bash
 # Generate SBOM first
-threat-radar sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
+tr sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
 
 # Scan the SBOM
-threat-radar cve scan-sbom /app/sbom_storage/nginx.json --auto-save
+tr cve scan-sbom /app/sbom_storage/nginx.json --auto-save
 
 # Check results
 ls -lh /app/storage/cve_storage/
@@ -156,10 +156,10 @@ ls -lh /app/storage/cve_storage/
 #### Database Operations
 ```bash
 # Check database status
-threat-radar cve db-status
+tr cve db-status
 
 # Update database
-threat-radar cve db-update
+tr cve db-update
 ```
 
 **Expected Results:**
@@ -173,10 +173,10 @@ threat-radar cve db-update
 #### Build Vulnerability Graph
 ```bash
 # Scan image first
-threat-radar cve scan-image alpine:3.18 --auto-save -o /tmp/scan.json
+tr cve scan-image alpine:3.18 --auto-save -o /tmp/scan.json
 
 # Build graph
-threat-radar graph build /tmp/scan.json -o /tmp/graph.graphml
+tr graph build /tmp/scan.json -o /tmp/graph.graphml
 
 # Verify
 ls -lh /tmp/graph.graphml
@@ -190,13 +190,13 @@ ls -lh /tmp/graph.graphml
 #### Query Graph
 ```bash
 # Show statistics
-threat-radar graph query /tmp/graph.graphml --stats
+tr graph query /tmp/graph.graphml --stats
 
 # Query specific CVE (if exists)
-threat-radar graph query /tmp/graph.graphml --cve CVE-2023-1234
+tr graph query /tmp/graph.graphml --cve CVE-2023-1234
 
 # Top vulnerable packages
-threat-radar graph query /tmp/graph.graphml --top-packages 10
+tr graph query /tmp/graph.graphml --top-packages 10
 ```
 
 **Expected Results:**
@@ -207,13 +207,13 @@ threat-radar graph query /tmp/graph.graphml --top-packages 10
 #### List Stored Graphs
 ```bash
 # Build with auto-save
-threat-radar graph build /tmp/scan.json --auto-save
+tr graph build /tmp/scan.json --auto-save
 
 # List all graphs
-threat-radar graph list
+tr graph list
 
 # Show graph info
-threat-radar graph info /app/storage/graph_storage/*.graphml
+tr graph info /app/storage/graph_storage/*.graphml
 ```
 
 **Expected Results:**
@@ -226,7 +226,7 @@ threat-radar graph info /app/storage/graph_storage/*.graphml
 
 #### JSON Report
 ```bash
-threat-radar report generate /tmp/scan.json -o /tmp/report.json -f json
+tr report generate /tmp/scan.json -o /tmp/report.json -f json
 
 # View summary
 cat /tmp/report.json | jq '.summary'
@@ -238,7 +238,7 @@ cat /tmp/report.json | jq '.summary'
 
 #### Markdown Report
 ```bash
-threat-radar report generate /tmp/scan.json -o /tmp/report.md -f markdown
+tr report generate /tmp/scan.json -o /tmp/report.md -f markdown
 
 # View
 head -50 /tmp/report.md
@@ -250,7 +250,7 @@ head -50 /tmp/report.md
 
 #### HTML Report
 ```bash
-threat-radar report generate /tmp/scan.json -o /tmp/report.html -f html
+tr report generate /tmp/scan.json -o /tmp/report.html -f html
 
 # Check size
 ls -lh /tmp/report.html
@@ -263,7 +263,7 @@ ls -lh /tmp/report.html
 
 #### Dashboard Export
 ```bash
-threat-radar report dashboard-export /tmp/scan.json -o /tmp/dashboard.json
+tr report dashboard-export /tmp/scan.json -o /tmp/dashboard.json
 
 # View structure
 cat /tmp/dashboard.json | jq 'keys'
@@ -288,13 +288,13 @@ Inside container:
 ls -la /workspace
 
 # Generate SBOM from local directory
-threat-radar sbom generate /workspace -o /app/sbom_storage/my-project.json
+tr sbom generate /workspace -o /app/sbom_storage/my-project.json
 
 # View stats
-threat-radar sbom stats /app/sbom_storage/my-project.json
+tr sbom stats /app/sbom_storage/my-project.json
 
 # Scan for vulnerabilities
-threat-radar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 
 # Check results
 ls -lh /app/storage/cve_storage/
@@ -340,18 +340,18 @@ rm /app/storage/test.txt
 
 ```bash
 # Lightweight images
-threat-radar cve scan-image alpine:3.18 --auto-save
-threat-radar cve scan-image busybox:latest --auto-save
+tr cve scan-image alpine:3.18 --auto-save
+tr cve scan-image busybox:latest --auto-save
 
 # Language runtimes
-threat-radar cve scan-image python:3.11-alpine --auto-save
-threat-radar cve scan-image node:20-alpine --auto-save
-threat-radar cve scan-image golang:1.21-alpine --auto-save
+tr cve scan-image python:3.11-alpine --auto-save
+tr cve scan-image node:20-alpine --auto-save
+tr cve scan-image golang:1.21-alpine --auto-save
 
 # Application images
-threat-radar cve scan-image nginx:alpine --auto-save
-threat-radar cve scan-image redis:alpine --auto-save
-threat-radar cve scan-image postgres:16-alpine --auto-save
+tr cve scan-image nginx:alpine --auto-save
+tr cve scan-image redis:alpine --auto-save
+tr cve scan-image postgres:16-alpine --auto-save
 
 # Check all results
 ls -lh /app/storage/cve_storage/
@@ -368,10 +368,10 @@ ls -lh /app/storage/cve_storage/
 
 #### Compare SBOMs
 ```bash
-threat-radar sbom docker alpine:3.17 -o /tmp/alpine-3.17.json
-threat-radar sbom docker alpine:3.18 -o /tmp/alpine-3.18.json
+tr sbom docker alpine:3.17 -o /tmp/alpine-3.17.json
+tr sbom docker alpine:3.18 -o /tmp/alpine-3.18.json
 
-threat-radar sbom compare /tmp/alpine-3.17.json /tmp/alpine-3.18.json
+tr sbom compare /tmp/alpine-3.17.json /tmp/alpine-3.18.json
 ```
 
 **Expected Results:**
@@ -380,8 +380,8 @@ threat-radar sbom compare /tmp/alpine-3.17.json /tmp/alpine-3.18.json
 
 #### Search in SBOM
 ```bash
-threat-radar sbom search /app/sbom_storage/alpine.json openssl
-threat-radar sbom search /app/sbom_storage/python.json pip
+tr sbom search /app/sbom_storage/alpine.json openssl
+tr sbom search /app/sbom_storage/python.json pip
 ```
 
 **Expected Results:**
@@ -390,9 +390,9 @@ threat-radar sbom search /app/sbom_storage/python.json pip
 
 #### List Components
 ```bash
-threat-radar sbom components /app/sbom_storage/python.json
-threat-radar sbom components /app/sbom_storage/python.json --type library
-threat-radar sbom components /app/sbom_storage/python.json --language python
+tr sbom components /app/sbom_storage/python.json
+tr sbom components /app/sbom_storage/python.json --type library
+tr sbom components /app/sbom_storage/python.json --language python
 ```
 
 **Expected Results:**
@@ -401,7 +401,7 @@ threat-radar sbom components /app/sbom_storage/python.json --language python
 
 #### Export to CSV
 ```bash
-threat-radar sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
+tr sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
 
 head -10 /tmp/packages.csv
 ```
@@ -541,9 +541,9 @@ A successful test run should show:
 
 ```bash
 # Minimal smoke test (5 minutes)
-threat-radar health check ✓
-threat-radar sbom docker alpine:3.18 -o /tmp/test.json ✓
-threat-radar cve scan-sbom /tmp/test.json ✓
+tr health check ✓
+tr sbom docker alpine:3.18 -o /tmp/test.json ✓
+tr cve scan-sbom /tmp/test.json ✓
 docker ps ✓
 
 # If all pass, environment is working correctly!

--- a/docs/docker/TESTING.md
+++ b/docs/docker/TESTING.md
@@ -25,22 +25,22 @@ cat /app/quick-test.sh
 
 ```bash
 # Show help
-tr --help
+tradar --help
 
 # Version info
-tr --version
+tradar --version
 
 # Health ping (quick)
-tr health ping
+tradar health ping
 
 # Full health check
-tr health check
+tradar health check
 
 # Verbose health check
-tr health check --verbose
+tradar health check --verbose
 
 # Show version details
-tr health version
+tradar health version
 ```
 
 **Expected Results:**
@@ -77,11 +77,11 @@ syft version
 
 #### Test Small Image (Alpine)
 ```bash
-tr sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
+tradar sbom docker alpine:3.18 -o /app/sbom_storage/alpine.json
 
 # Verify output
 ls -lh /app/sbom_storage/alpine.json
-tr sbom read /app/sbom_storage/alpine.json
+tradar sbom read /app/sbom_storage/alpine.json
 ```
 
 **Expected Results:**
@@ -91,10 +91,10 @@ tr sbom read /app/sbom_storage/alpine.json
 
 #### Test Medium Image (Python)
 ```bash
-tr sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
+tradar sbom docker python:3.11-alpine -o /app/sbom_storage/python.json
 
 # View stats
-tr sbom stats /app/sbom_storage/python.json
+tradar sbom stats /app/sbom_storage/python.json
 ```
 
 **Expected Results:**
@@ -104,7 +104,7 @@ tr sbom stats /app/sbom_storage/python.json
 
 #### Test Large Image (Full Python)
 ```bash
-tr sbom docker python:3.11 -o /app/sbom_storage/python-full.json
+tradar sbom docker python:3.11 -o /app/sbom_storage/python-full.json
 
 # Compare sizes
 ls -lh /app/sbom_storage/python*.json
@@ -121,13 +121,13 @@ ls -lh /app/sbom_storage/python*.json
 #### Scan Docker Image Directly
 ```bash
 # Basic scan
-tr cve scan-image alpine:3.18 -o /tmp/scan-alpine.json
+tradar cve scan-image alpine:3.18 -o /tmp/scan-alpine.json
 
 # With severity filter
-tr cve scan-image alpine:3.18 --severity HIGH -o /tmp/scan-high.json
+tradar cve scan-image alpine:3.18 --severity HIGH -o /tmp/scan-high.json
 
 # With auto-save
-tr cve scan-image busybox:latest --auto-save
+tradar cve scan-image busybox:latest --auto-save
 ```
 
 **Expected Results:**
@@ -139,10 +139,10 @@ tr cve scan-image busybox:latest --auto-save
 #### Scan SBOM File
 ```bash
 # Generate SBOM first
-tr sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
+tradar sbom docker nginx:alpine -o /app/sbom_storage/nginx.json
 
 # Scan the SBOM
-tr cve scan-sbom /app/sbom_storage/nginx.json --auto-save
+tradar cve scan-sbom /app/sbom_storage/nginx.json --auto-save
 
 # Check results
 ls -lh /app/storage/cve_storage/
@@ -156,10 +156,10 @@ ls -lh /app/storage/cve_storage/
 #### Database Operations
 ```bash
 # Check database status
-tr cve db-status
+tradar cve db-status
 
 # Update database
-tr cve db-update
+tradar cve db-update
 ```
 
 **Expected Results:**
@@ -173,10 +173,10 @@ tr cve db-update
 #### Build Vulnerability Graph
 ```bash
 # Scan image first
-tr cve scan-image alpine:3.18 --auto-save -o /tmp/scan.json
+tradar cve scan-image alpine:3.18 --auto-save -o /tmp/scan.json
 
 # Build graph
-tr graph build /tmp/scan.json -o /tmp/graph.graphml
+tradar graph build /tmp/scan.json -o /tmp/graph.graphml
 
 # Verify
 ls -lh /tmp/graph.graphml
@@ -190,13 +190,13 @@ ls -lh /tmp/graph.graphml
 #### Query Graph
 ```bash
 # Show statistics
-tr graph query /tmp/graph.graphml --stats
+tradar graph query /tmp/graph.graphml --stats
 
 # Query specific CVE (if exists)
-tr graph query /tmp/graph.graphml --cve CVE-2023-1234
+tradar graph query /tmp/graph.graphml --cve CVE-2023-1234
 
 # Top vulnerable packages
-tr graph query /tmp/graph.graphml --top-packages 10
+tradar graph query /tmp/graph.graphml --top-packages 10
 ```
 
 **Expected Results:**
@@ -207,13 +207,13 @@ tr graph query /tmp/graph.graphml --top-packages 10
 #### List Stored Graphs
 ```bash
 # Build with auto-save
-tr graph build /tmp/scan.json --auto-save
+tradar graph build /tmp/scan.json --auto-save
 
 # List all graphs
-tr graph list
+tradar graph list
 
 # Show graph info
-tr graph info /app/storage/graph_storage/*.graphml
+tradar graph info /app/storage/graph_storage/*.graphml
 ```
 
 **Expected Results:**
@@ -226,7 +226,7 @@ tr graph info /app/storage/graph_storage/*.graphml
 
 #### JSON Report
 ```bash
-tr report generate /tmp/scan.json -o /tmp/report.json -f json
+tradar report generate /tmp/scan.json -o /tmp/report.json -f json
 
 # View summary
 cat /tmp/report.json | jq '.summary'
@@ -238,7 +238,7 @@ cat /tmp/report.json | jq '.summary'
 
 #### Markdown Report
 ```bash
-tr report generate /tmp/scan.json -o /tmp/report.md -f markdown
+tradar report generate /tmp/scan.json -o /tmp/report.md -f markdown
 
 # View
 head -50 /tmp/report.md
@@ -250,7 +250,7 @@ head -50 /tmp/report.md
 
 #### HTML Report
 ```bash
-tr report generate /tmp/scan.json -o /tmp/report.html -f html
+tradar report generate /tmp/scan.json -o /tmp/report.html -f html
 
 # Check size
 ls -lh /tmp/report.html
@@ -263,7 +263,7 @@ ls -lh /tmp/report.html
 
 #### Dashboard Export
 ```bash
-tr report dashboard-export /tmp/scan.json -o /tmp/dashboard.json
+tradar report dashboard-export /tmp/scan.json -o /tmp/dashboard.json
 
 # View structure
 cat /tmp/dashboard.json | jq 'keys'
@@ -288,13 +288,13 @@ Inside container:
 ls -la /workspace
 
 # Generate SBOM from local directory
-tr sbom generate /workspace -o /app/sbom_storage/my-project.json
+tradar sbom generate /workspace -o /app/sbom_storage/my-project.json
 
 # View stats
-tr sbom stats /app/sbom_storage/my-project.json
+tradar sbom stats /app/sbom_storage/my-project.json
 
 # Scan for vulnerabilities
-tr cve scan-sbom /app/sbom_storage/my-project.json --auto-save
+tradar cve scan-sbom /app/sbom_storage/my-project.json --auto-save
 
 # Check results
 ls -lh /app/storage/cve_storage/
@@ -340,18 +340,18 @@ rm /app/storage/test.txt
 
 ```bash
 # Lightweight images
-tr cve scan-image alpine:3.18 --auto-save
-tr cve scan-image busybox:latest --auto-save
+tradar cve scan-image alpine:3.18 --auto-save
+tradar cve scan-image busybox:latest --auto-save
 
 # Language runtimes
-tr cve scan-image python:3.11-alpine --auto-save
-tr cve scan-image node:20-alpine --auto-save
-tr cve scan-image golang:1.21-alpine --auto-save
+tradar cve scan-image python:3.11-alpine --auto-save
+tradar cve scan-image node:20-alpine --auto-save
+tradar cve scan-image golang:1.21-alpine --auto-save
 
 # Application images
-tr cve scan-image nginx:alpine --auto-save
-tr cve scan-image redis:alpine --auto-save
-tr cve scan-image postgres:16-alpine --auto-save
+tradar cve scan-image nginx:alpine --auto-save
+tradar cve scan-image redis:alpine --auto-save
+tradar cve scan-image postgres:16-alpine --auto-save
 
 # Check all results
 ls -lh /app/storage/cve_storage/
@@ -368,10 +368,10 @@ ls -lh /app/storage/cve_storage/
 
 #### Compare SBOMs
 ```bash
-tr sbom docker alpine:3.17 -o /tmp/alpine-3.17.json
-tr sbom docker alpine:3.18 -o /tmp/alpine-3.18.json
+tradar sbom docker alpine:3.17 -o /tmp/alpine-3.17.json
+tradar sbom docker alpine:3.18 -o /tmp/alpine-3.18.json
 
-tr sbom compare /tmp/alpine-3.17.json /tmp/alpine-3.18.json
+tradar sbom compare /tmp/alpine-3.17.json /tmp/alpine-3.18.json
 ```
 
 **Expected Results:**
@@ -380,8 +380,8 @@ tr sbom compare /tmp/alpine-3.17.json /tmp/alpine-3.18.json
 
 #### Search in SBOM
 ```bash
-tr sbom search /app/sbom_storage/alpine.json openssl
-tr sbom search /app/sbom_storage/python.json pip
+tradar sbom search /app/sbom_storage/alpine.json openssl
+tradar sbom search /app/sbom_storage/python.json pip
 ```
 
 **Expected Results:**
@@ -390,9 +390,9 @@ tr sbom search /app/sbom_storage/python.json pip
 
 #### List Components
 ```bash
-tr sbom components /app/sbom_storage/python.json
-tr sbom components /app/sbom_storage/python.json --type library
-tr sbom components /app/sbom_storage/python.json --language python
+tradar sbom components /app/sbom_storage/python.json
+tradar sbom components /app/sbom_storage/python.json --type library
+tradar sbom components /app/sbom_storage/python.json --language python
 ```
 
 **Expected Results:**
@@ -401,7 +401,7 @@ tr sbom components /app/sbom_storage/python.json --language python
 
 #### Export to CSV
 ```bash
-tr sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
+tradar sbom export /app/sbom_storage/alpine.json -o /tmp/packages.csv -f csv
 
 head -10 /tmp/packages.csv
 ```
@@ -541,9 +541,9 @@ A successful test run should show:
 
 ```bash
 # Minimal smoke test (5 minutes)
-tr health check ✓
-tr sbom docker alpine:3.18 -o /tmp/test.json ✓
-tr cve scan-sbom /tmp/test.json ✓
+tradar health check ✓
+tradar sbom docker alpine:3.18 -o /tmp/test.json ✓
+tradar cve scan-sbom /tmp/test.json ✓
 docker ps ✓
 
 # If all pass, environment is working correctly!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ ai = [
 ]
 
 [project.scripts]
-tr = "threat_radar.cli.__main__:main"
+tradar = "threat_radar.cli.__main__:main"
 threat-radar = "threat_radar.cli.__main__:main"
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,8 @@ ai = [
 ]
 
 [project.scripts]
+tr = "threat_radar.cli.__main__:main"
 threat-radar = "threat_radar.cli.__main__:main"
-tradar = "threat_radar.cli.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/Threat-Radar/tr"

--- a/test_cli_aliases.sh
+++ b/test_cli_aliases.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Test script to verify both 'tr' and 'threat-radar' commands work as aliases
+# This tests Issue #123 - CLI command rename
+
+set -e  # Exit on error
+
+echo "========================================="
+echo "Testing CLI Command Aliases (Issue #123)"
+echo "========================================="
+echo ""
+
+# Test 1: Check both commands are available
+echo "Test 1: Checking if both commands exist..."
+echo "-------------------------------------------"
+
+if command -v tr &> /dev/null; then
+    echo "✓ 'tr' command found"
+    tr --version
+else
+    echo "✗ 'tr' command not found"
+    exit 1
+fi
+
+echo ""
+
+if command -v threat-radar &> /dev/null; then
+    echo "✓ 'threat-radar' command found (backward compatibility)"
+    threat-radar --version
+else
+    echo "✗ 'threat-radar' command not found"
+    exit 1
+fi
+
+echo ""
+echo "Test 2: Comparing help output..."
+echo "-------------------------------------------"
+
+# Test 2: Verify both commands show same help
+tr --help > /tmp/tr_help.txt
+threat-radar --help > /tmp/threat-radar_help.txt
+
+if diff /tmp/tr_help.txt /tmp/threat-radar_help.txt &> /dev/null; then
+    echo "✓ Both commands show identical help output"
+else
+    echo "✗ Help output differs between commands"
+    exit 1
+fi
+
+echo ""
+echo "Test 3: Testing basic commands..."
+echo "-------------------------------------------"
+
+# Test 3: Test basic command functionality
+echo "Testing 'tr --help':"
+tr --help | head -5
+
+echo ""
+echo "Testing 'threat-radar --help':"
+threat-radar --help | head -5
+
+echo ""
+echo "========================================="
+echo "All Tests Passed! ✓"
+echo "========================================="
+echo ""
+echo "Summary:"
+echo "- 'tr' is the new primary command"
+echo "- 'threat-radar' works as an alias for backward compatibility"
+echo "- Both commands are functionally identical"
+echo ""
+echo "Recommendation: Update your scripts to use 'tr' going forward"

--- a/test_cli_aliases.sh
+++ b/test_cli_aliases.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Test script to verify both 'tr' and 'threat-radar' commands work as aliases
-# This tests Issue #123 - CLI command rename
+# Test script to verify both 'tradar' and 'threat-radar' commands work as aliases
+# This tests Issue #126 - Fix CLI command from 'tr' to 'tradar' (Unix tr conflict)
 
 set -e  # Exit on error
 
 echo "========================================="
-echo "Testing CLI Command Aliases (Issue #123)"
+echo "Testing CLI Command Aliases (Issue #126)"
 echo "========================================="
 echo ""
 
@@ -13,11 +13,11 @@ echo ""
 echo "Test 1: Checking if both commands exist..."
 echo "-------------------------------------------"
 
-if command -v tr &> /dev/null; then
-    echo "✓ 'tr' command found"
-    tr --version
+if command -v tradar &> /dev/null; then
+    echo "✓ 'tradar' command found"
+    tradar --version
 else
-    echo "✗ 'tr' command not found"
+    echo "✗ 'tradar' command not found"
     exit 1
 fi
 
@@ -36,10 +36,10 @@ echo "Test 2: Comparing help output..."
 echo "-------------------------------------------"
 
 # Test 2: Verify both commands show same help
-tr --help > /tmp/tr_help.txt
+tradar --help > /tmp/tradar_help.txt
 threat-radar --help > /tmp/threat-radar_help.txt
 
-if diff /tmp/tr_help.txt /tmp/threat-radar_help.txt &> /dev/null; then
+if diff /tmp/tradar_help.txt /tmp/threat-radar_help.txt &> /dev/null; then
     echo "✓ Both commands show identical help output"
 else
     echo "✗ Help output differs between commands"
@@ -51,8 +51,8 @@ echo "Test 3: Testing basic commands..."
 echo "-------------------------------------------"
 
 # Test 3: Test basic command functionality
-echo "Testing 'tr --help':"
-tr --help | head -5
+echo "Testing 'tradar --help':"
+tradar --help | head -5
 
 echo ""
 echo "Testing 'threat-radar --help':"
@@ -64,8 +64,8 @@ echo "All Tests Passed! ✓"
 echo "========================================="
 echo ""
 echo "Summary:"
-echo "- 'tr' is the new primary command"
+echo "- 'tradar' is the new primary command (no Unix tr conflict)"
 echo "- 'threat-radar' works as an alias for backward compatibility"
 echo "- Both commands are functionally identical"
 echo ""
-echo "Recommendation: Update your scripts to use 'tr' going forward"
+echo "Recommendation: Update your scripts to use 'tradar' going forward"

--- a/threat_radar/__init__.py
+++ b/threat_radar/__init__.py
@@ -20,9 +20,9 @@ Quick start:
     >>> analysis = analyzer.analyze_scan_result(result)
 
 For CLI usage:
-    $ threat-radar cve scan-image alpine:3.18 --auto-save
-    $ threat-radar ai analyze scan-results.json
-    $ threat-radar report generate scan-results.json -o report.html
+    $ tr cve scan-image alpine:3.18 --auto-save
+    $ tr ai analyze scan-results.json
+    $ tr report generate scan-results.json -o report.html
 """
 
 # Core scanning and analysis

--- a/threat_radar/cli/ai.py
+++ b/threat_radar/cli/ai.py
@@ -130,22 +130,22 @@ def analyze_vulnerabilities(
 
     Examples:
         # Auto batch for large scans (recommended)
-        threat-radar ai analyze cve-results.json
+        tr ai analyze cve-results.json
 
         # Analyze only critical and high severity vulnerabilities
-        threat-radar ai analyze scan.json --severity high
+        tr ai analyze scan.json --severity high
 
         # Force batch mode with custom size
-        threat-radar ai analyze scan.json --batch-mode enabled --batch-size 30
+        tr ai analyze scan.json --batch-mode enabled --batch-size 30
 
         # Combine severity filter with batching
-        threat-radar ai analyze large-scan.json --severity critical --batch-size 20
+        tr ai analyze large-scan.json --severity critical --batch-size 20
 
         # Disable batching (may fail for large scans)
-        threat-radar ai analyze scan.json --batch-mode disabled
+        tr ai analyze scan.json --batch-mode disabled
 
         # With specific AI provider
-        threat-radar ai analyze results.json --provider openai --model gpt-4o
+        tr ai analyze results.json --provider openai --model gpt-4o
     """
     with handle_cli_error("analyzing vulnerabilities", console):
         # Load CVE scan results
@@ -362,10 +362,10 @@ def prioritize_vulnerabilities(
     - Adjust --batch-size for optimal performance (default: 25)
 
     Examples:
-        threat-radar ai prioritize cve-results.json
-        threat-radar ai prioritize results.json --top 20
-        threat-radar ai prioritize scan.json -o priorities.json
-        threat-radar ai prioritize scan.json --severity high --batch-size 20
+        tr ai prioritize cve-results.json
+        tr ai prioritize results.json --top 20
+        tr ai prioritize scan.json -o priorities.json
+        tr ai prioritize scan.json --severity high --batch-size 20
     """
     with handle_cli_error("prioritizing vulnerabilities", console):
         # Load and analyze
@@ -605,10 +605,10 @@ def generate_remediation(
     - Adjust --batch-size for optimal performance (default: 25)
 
     Examples:
-        threat-radar ai remediate cve-results.json
-        threat-radar ai remediate results.json -o remediation.json
-        threat-radar ai remediate scan.json --provider ollama
-        threat-radar ai remediate scan.json --severity critical --batch-size 20
+        tr ai remediate cve-results.json
+        tr ai remediate results.json -o remediation.json
+        tr ai remediate scan.json --provider ollama
+        tr ai remediate scan.json --severity critical --batch-size 20
     """
     with handle_cli_error("generating remediation plan", console):
         # Load scan results
@@ -834,16 +834,16 @@ def analyze_with_business_context(
 
     Examples:
         # Analyze with business context
-        threat-radar ai analyze-with-context cve-scan.json production-env.json
+        tr ai analyze-with-context cve-scan.json production-env.json
 
         # Specify which asset the scan corresponds to
-        threat-radar ai analyze-with-context scan.json env.json --asset-id api-gateway-001
+        tr ai analyze-with-context scan.json env.json --asset-id api-gateway-001
 
         # Save results and show top 20 business risks
-        threat-radar ai analyze-with-context scan.json env.json -o analysis.json --show-top 20
+        tr ai analyze-with-context scan.json env.json -o analysis.json --show-top 20
 
         # Use with specific AI provider
-        threat-radar ai analyze-with-context scan.json env.json --provider ollama --model llama2
+        tr ai analyze-with-context scan.json env.json --provider ollama --model llama2
     """
     with handle_cli_error("analyzing vulnerabilities with business context", console):
         # Load CVE scan results
@@ -1098,18 +1098,18 @@ def threat_model(
     Examples:
 
         # Basic threat modeling (auto-selects relevant threat actors)
-        threat-radar ai threat-model graph.graphml
+        tr ai threat-model graph.graphml
 
         # Analyze specific threat actor
-        threat-radar ai threat-model graph.graphml -t apt28 -s 15
+        tr ai threat-model graph.graphml -t apt28 -s 15
 
         # With business context for better impact assessment
-        threat-radar ai threat-model graph.graphml \\
+        tr ai threat-model graph.graphml \\
             -e production-env.json -t ransomware --auto-save
 
         # Compare multiple threat actors
-        threat-radar ai threat-model graph.graphml -t apt28 -o apt28-model.json
-        threat-radar ai threat-model graph.graphml -t script-kiddie -o scriptkiddie-model.json
+        tr ai threat-model graph.graphml -t apt28 -o apt28-model.json
+        tr ai threat-model graph.graphml -t script-kiddie -o scriptkiddie-model.json
     """
     try:
         # Validate graph file exists

--- a/threat_radar/cli/app.py
+++ b/threat_radar/cli/app.py
@@ -94,9 +94,9 @@ def main_callback(
       3 (-vv):         Debug - everything
 
     Examples:
-      threat-radar -v cve scan-image alpine:3.18
-      threat-radar --config myconfig.json ai analyze scan.json
-      threat-radar -vv --output-format json sbom docker python:3.11
+      tr -v cve scan-image alpine:3.18
+      tr --config myconfig.json ai analyze scan.json
+      tr -vv --output-format json sbom docker python:3.11
     """
     # Apply quiet flag (overrides verbosity)
     if quiet:

--- a/threat_radar/cli/config.py
+++ b/threat_radar/cli/config.py
@@ -23,9 +23,9 @@ def show_config(
     Show current configuration.
 
     Examples:
-      threat-radar config show
-      threat-radar config show scan.severity
-      threat-radar config show ai.provider
+      tr config show
+      tr config show scan.severity
+      tr config show ai.provider
     """
     config_manager = get_config_manager()
 
@@ -62,9 +62,9 @@ def set_config(
     Set configuration value.
 
     Examples:
-      threat-radar config set scan.severity HIGH
-      threat-radar config set ai.provider ollama
-      threat-radar config set output.verbosity 2
+      tr config set scan.severity HIGH
+      tr config set ai.provider ollama
+      tr config set output.verbosity 2
     """
     config_manager = get_config_manager()
 
@@ -114,9 +114,9 @@ def init_config(
     Creates ~/.threat-radar/config.json with default settings.
 
     Examples:
-      threat-radar config init
-      threat-radar config init --path ./my-config.json
-      threat-radar config init --force  # Overwrite existing
+      tr config init
+      tr config init --path ./my-config.json
+      tr config init --force  # Overwrite existing
     """
     # Check if file exists
     if path.exists() and not force:
@@ -130,7 +130,7 @@ def init_config(
 
     console.print(f"[green]✓[/green] Created configuration file: {saved_path}")
     console.print("\nYou can edit this file directly or use:")
-    console.print("  threat-radar config set <key> <value>")
+    console.print("  tr config set <key> <value>")
 
 
 @app.command("path")
@@ -181,8 +181,8 @@ def validate_config(
     Checks if a configuration file is valid and shows any errors.
 
     Examples:
-      threat-radar config validate
-      threat-radar config validate ./my-config.json
+      tr config validate
+      tr config validate ./my-config.json
     """
     if config_file is None:
         # Validate current config

--- a/threat_radar/cli/cve.py
+++ b/threat_radar/cli/cve.py
@@ -65,12 +65,12 @@ def scan_docker_image(
     timestamped filenames. This is useful for keeping a history of scan results.
 
     Examples:
-        threat-radar cve scan-image alpine:3.18
-        threat-radar cve scan-image python:3.11 --severity HIGH
-        threat-radar cve scan-image ubuntu:22.04 --only-fixed -o results.json
-        threat-radar cve scan-image nginx:latest --cleanup  # Remove after scan
-        threat-radar cve scan-image myapp:latest --auto-save  # Auto-save to storage/cve_storage/
-        threat-radar cve scan-image myapp:latest --as --cleanup  # Both features
+        tr cve scan-image alpine:3.18
+        tr cve scan-image python:3.11 --severity HIGH
+        tr cve scan-image ubuntu:22.04 --only-fixed -o results.json
+        tr cve scan-image nginx:latest --cleanup  # Remove after scan
+        tr cve scan-image myapp:latest --auto-save  # Auto-save to storage/cve_storage/
+        tr cve scan-image myapp:latest --as --cleanup  # Both features
     """
     with handle_cli_error("scanning image", console):
         # Use cleanup context to manage Docker image lifecycle
@@ -229,11 +229,11 @@ def scan_sbom_file(
     timestamped filenames.
 
     Examples:
-        threat-radar cve scan-sbom my-app-sbom.json
-        threat-radar cve scan-sbom docker-sbom.json --severity HIGH
-        threat-radar cve scan-sbom sbom.json --only-fixed -o results.json
-        threat-radar cve scan-sbom sbom.json --cleanup --image alpine:3.18
-        threat-radar cve scan-sbom sbom.json --auto-save  # Auto-save to storage/cve_storage/
+        tr cve scan-sbom my-app-sbom.json
+        tr cve scan-sbom docker-sbom.json --severity HIGH
+        tr cve scan-sbom sbom.json --only-fixed -o results.json
+        tr cve scan-sbom sbom.json --cleanup --image alpine:3.18
+        tr cve scan-sbom sbom.json --auto-save  # Auto-save to storage/cve_storage/
     """
     with handle_cli_error("scanning SBOM", console):
         # Determine if we should cleanup and what image to cleanup
@@ -404,10 +404,10 @@ def scan_directory(
     timestamped filenames.
 
     Examples:
-        threat-radar cve scan-directory ./my-app
-        threat-radar cve scan-directory /path/to/project --severity MEDIUM
-        threat-radar cve scan-directory . --only-fixed -o results.json
-        threat-radar cve scan-directory ./src --auto-save  # Auto-save to storage/cve_storage/
+        tr cve scan-directory ./my-app
+        tr cve scan-directory /path/to/project --severity MEDIUM
+        tr cve scan-directory . --only-fixed -o results.json
+        tr cve scan-directory ./src --auto-save  # Auto-save to storage/cve_storage/
     """
     with handle_cli_error("scanning directory", console):
         with Progress(
@@ -519,7 +519,7 @@ def update_database():
     This is typically done automatically, but can be forced manually.
 
     Example:
-        threat-radar cve db-update
+        tr cve db-update
     """
     with handle_cli_error("updating database", console):
         with Progress(
@@ -549,7 +549,7 @@ def database_status():
     Displays information about the current Grype database.
 
     Example:
-        threat-radar cve db-status
+        tr cve db-status
     """
     with handle_cli_error("fetching database status", console):
         grype = GrypeClient()
@@ -687,12 +687,12 @@ def list_scans(
     scan target, type, total vulnerabilities, severity breakdown, and scan date.
 
     Examples:
-        threat-radar cve list-scans
-        threat-radar cve list-scans --type image
-        threat-radar cve list-scans --severity critical
-        threat-radar cve list-scans --details
-        threat-radar cve list-scans --limit 10 --sort-by vulnerabilities
-        threat-radar cve list-scans --format json
+        tr cve list-scans
+        tr cve list-scans --type image
+        tr cve list-scans --severity critical
+        tr cve list-scans --details
+        tr cve list-scans --limit 10 --sort-by vulnerabilities
+        tr cve list-scans --format json
     """
     from ..core.cve_storage_manager import CVEStorageManager
     from ..utils.cve_utils import display_scans_table
@@ -767,13 +767,13 @@ def show_scan(
     Shows vulnerabilities with filtering, grouping, and export capabilities.
 
     Examples:
-        threat-radar cve show storage/cve_storage/alpine*.json
-        threat-radar cve show node_16_*.json --severity critical
-        threat-radar cve show scan.json --package openssl
-        threat-radar cve show scan.json --cve-id CVE-2023-4863
-        threat-radar cve show scan.json --no-fix --severity high
-        threat-radar cve show scan.json --group-by package
-        threat-radar cve show scan.json --severity high --export critical.json
+        tr cve show storage/cve_storage/alpine*.json
+        tr cve show node_16_*.json --severity critical
+        tr cve show scan.json --package openssl
+        tr cve show scan.json --cve-id CVE-2023-4863
+        tr cve show scan.json --no-fix --severity high
+        tr cve show scan.json --group-by package
+        tr cve show scan.json --severity high --export critical.json
     """
     from ..core.cve_storage_manager import CVEStorageManager
     from ..utils.cve_utils import (
@@ -916,12 +916,12 @@ def search_scans(
     Searches through all scans in storage/cve_storage/ directory.
 
     Examples:
-        threat-radar cve search CVE-2023-4863
-        threat-radar cve search openssl --query-type package
-        threat-radar cve search "buffer overflow" --query-type description
-        threat-radar cve search "node" --severity critical
-        threat-radar cve search "CVE-2023*" --scans "*node*"
-        threat-radar cve search "libwebp" --exact-match
+        tr cve search CVE-2023-4863
+        tr cve search openssl --query-type package
+        tr cve search "buffer overflow" --query-type description
+        tr cve search "node" --severity critical
+        tr cve search "CVE-2023*" --scans "*node*"
+        tr cve search "libwebp" --exact-match
     """
     from ..core.cve_storage_manager import CVEStorageManager
     from ..utils.cve_utils import display_search_results
@@ -975,10 +975,10 @@ def show_stats(
     Displays total vulnerabilities, severity breakdown, top CVEs, and more.
 
     Examples:
-        threat-radar cve stats
-        threat-radar cve stats --type image
-        threat-radar cve stats --scans "*node*"
-        threat-radar cve stats --format json
+        tr cve stats
+        tr cve stats --type image
+        tr cve stats --scans "*node*"
+        tr cve stats --format json
     """
     from ..core.cve_storage_manager import CVEStorageManager
     from ..utils.cve_utils import display_aggregate_stats

--- a/threat_radar/cli/env.py
+++ b/threat_radar/cli/env.py
@@ -536,9 +536,9 @@ def template(
     console.print(f"[green]✓[/green] Template created: {output}")
     console.print("\n[bold]Next steps:[/bold]")
     console.print("  1. Edit the template with your infrastructure details")
-    console.print(f"  2. Validate: threat-radar env validate {output}")
+    console.print(f"  2. Validate: tr env validate {output}")
     console.print(
-        f"  3. Build graph: threat-radar env build-graph {output} --auto-save"
+        f"  3. Build graph: tr env build-graph {output} --auto-save"
     )
 
 

--- a/threat_radar/cli/report.py
+++ b/threat_radar/cli/report.py
@@ -113,19 +113,19 @@ def generate_report(
 
     Examples:
         # Generate detailed report with AI summary
-        threat-radar report generate scan-results.json -o report.html -f html
+        tr report generate scan-results.json -o report.html -f html
 
         # Executive summary in Markdown
-        threat-radar report generate scan-results.json -o summary.md -f markdown --level executive
+        tr report generate scan-results.json -o summary.md -f markdown --level executive
 
         # Critical-only issues in JSON
-        threat-radar report generate scan-results.json -o critical.json --level critical-only
+        tr report generate scan-results.json -o critical.json --level critical-only
 
         # Report with attack path analysis
-        threat-radar report generate scan.json -o report.html --attack-paths attack-paths.json
+        tr report generate scan.json -o report.html --attack-paths attack-paths.json
 
         # Full report with custom AI model and attack paths
-        threat-radar report generate scan-results.json --ai-provider ollama --ai-model llama2 --attack-paths paths.json
+        tr report generate scan-results.json --ai-provider ollama --ai-model llama2 --attack-paths paths.json
     """
     with handle_cli_error("generating report", console):
         # Validate report level
@@ -268,7 +268,7 @@ def export_dashboard_data(
     Generates JSON data optimized for dashboard integrations (Grafana, custom dashboards, etc.).
 
     Example:
-        threat-radar report dashboard-export scan-results.json -o dashboard.json
+        tr report dashboard-export scan-results.json -o dashboard.json
     """
     with handle_cli_error("exporting dashboard data", console):
         # Load scan results
@@ -324,7 +324,7 @@ def compare_reports(
     Shows new vulnerabilities, fixed vulnerabilities, and overall trends.
 
     Example:
-        threat-radar report compare old-scan.json new-scan.json -o comparison.md
+        tr report compare old-scan.json new-scan.json -o comparison.md
     """
     with handle_cli_error("comparing reports", console):
         # Load both scan results

--- a/threat_radar/environment/README.md
+++ b/threat_radar/environment/README.md
@@ -325,14 +325,14 @@ terraform show -json | jq '{
 
 ```bash
 # Extract from K8s cluster
-kubectl get all -o json | threat-radar env convert-k8s > environment.json
+kubectl get all -o json | tr env convert-k8s > environment.json
 ```
 
 ### From Docker Compose
 
 ```bash
 # Convert docker-compose.yml
-threat-radar env convert-compose docker-compose.yml > environment.json
+tr env convert-compose docker-compose.yml > environment.json
 ```
 
 ### From CMDB/Asset Inventory
@@ -420,8 +420,8 @@ Auto-generate environment files:
 # .github/workflows/update-environment.yml
 - name: Generate Environment Config
   run: |
-    threat-radar env generate-from-terraform > environment.json
-    threat-radar env validate environment.json
+    tr env generate-from-terraform > environment.json
+    tr env validate environment.json
 ```
 
 ## Roadmap

--- a/threat_radar/environment/README.md
+++ b/threat_radar/environment/README.md
@@ -325,14 +325,14 @@ terraform show -json | jq '{
 
 ```bash
 # Extract from K8s cluster
-kubectl get all -o json | tr env convert-k8s > environment.json
+kubectl get all -o json | tradar env convert-k8s > environment.json
 ```
 
 ### From Docker Compose
 
 ```bash
 # Convert docker-compose.yml
-tr env convert-compose docker-compose.yml > environment.json
+tradar env convert-compose docker-compose.yml > environment.json
 ```
 
 ### From CMDB/Asset Inventory
@@ -420,8 +420,8 @@ Auto-generate environment files:
 # .github/workflows/update-environment.yml
 - name: Generate Environment Config
   run: |
-    tr env generate-from-terraform > environment.json
-    tr env validate environment.json
+    tradar env generate-from-terraform > environment.json
+    tradar env validate environment.json
 ```
 
 ## Roadmap

--- a/threat_radar/utils/report_formatters.py
+++ b/threat_radar/utils/report_formatters.py
@@ -832,7 +832,7 @@ class PDFFormatter(ReportFormatter):
             raise ImportError(
                 "PDF export requires weasyprint. Install it with:\n"
                 "  pip install weasyprint\n"
-                "Or install threat-radar with PDF support:\n"
+                "Or install tr with PDF support:\n"
                 "  pip install threat-radar[pdf]"
             )
 


### PR DESCRIPTION
# Change Primary CLI Command from 'threat-radar' to 'tr'

Fixes #123

## Overview
This PR changes the primary CLI command from `threat-radar` to the shorter and more convenient `tr`, while maintaining full backward compatibility with the existing `threat-radar` command.

## Changes Made

### 1. **pyproject.toml** ✅
- Changed primary command entry point from `threat-radar` to `tr`
- Kept `threat-radar` as an alias for backward compatibility
- Removed the old `tradar` alias in favor of the cleaner `tr`

```toml
[project.scripts]
tr = "threat_radar.cli.__main__:main"
threat-radar = "threat_radar.cli.__main__:main"
```

### 2. **Documentation Updates** ✅
Updated all command examples in:
- `README.md` - Main documentation with quick start examples
- `docs/INSTALLATION.md` - Installation and verification steps
- `docs/PUBLISHING.md` - Publishing instructions
- `docs/docker/DOCKER_INTERACTIVE.md` - Docker examples
- `docs/docker/DOCKER_LOCAL_SCANNING.md` - Local scanning guides
- `docs/docker/TESTING.md` - Testing procedures
- `docker/README.md` - Docker setup documentation
- `CLAUDE.md` - Complete CLI reference
- `threat_radar/environment/README.md` - Environment documentation

All examples now use `tr` as the primary command:
```bash
# Old
threat-radar cve scan-image alpine:3.18

# New
tr cve scan-image alpine:3.18
```

### 3. **Shell Scripts** ✅
Updated test and utility scripts:
- `docker/quick-test.sh` - Quick testing script
- `docker/test-commands.sh` - Comprehensive command tests
- `Makefile` - Build and development commands
- Added `test_cli_aliases.sh` - New script to verify both commands work

### 4. **GitHub Workflows** ✅
- `.github/workflows/test.yml` - Tests both `tr` and `threat-radar` for compatibility
- `.github/workflows/release.yml` - Updated release verification to use `tr`

### 5. **Python Code** ✅
Updated docstrings and examples in:
- `threat_radar/__init__.py`
- `threat_radar/cli/ai.py`
- `threat_radar/cli/app.py`
- `threat_radar/cli/config.py`
- `threat_radar/cli/cve.py`
- `threat_radar/cli/env.py`
- `threat_radar/cli/report.py`
- `threat_radar/utils/report_formatters.py`

## Backward Compatibility

**✓ Full backward compatibility maintained**

The `threat-radar` command still works exactly as before. Existing scripts and workflows will continue to function without any changes required.

Both commands are functionally identical:
```bash
tr --help              # New primary command
threat-radar --help    # Still works (alias)
```

## Testing Instructions

### 1. Clone and checkout this branch:
```bash
git clone https://github.com/Threat-Radar/tr.git
cd tr
git checkout feature/cli-rename-tr
```

### 2. Install in development mode:
```bash
pip install -e .
```

### 3. Verify both commands work:
```bash
# Run the test script
./test_cli_aliases.sh

# Or test manually
tr --version
threat-radar --version

tr --help
threat-radar --help

# Test a basic scan
tr cve scan-image alpine:3.18
threat-radar cve scan-image alpine:3.18
```

### 4. Expected results:
- Both `tr` and `threat-radar` commands should be available
- Both commands should show identical output
- All functionality should work with either command
- Test script should show "All Tests Passed! ✓"

## Files Changed
- 22 files modified with command examples updated
- 1 new test script added
- ~750 lines changed (mostly command examples in documentation)

## Review Checklist
- [x] Primary command changed from `threat-radar` to `tr` in pyproject.toml
- [x] Backward compatibility maintained (`threat-radar` still works)
- [x] All documentation updated with new command examples
- [x] All shell scripts updated
- [x] GitHub workflows updated and test both commands
- [x] Python docstrings and examples updated
- [x] Test script added to verify both commands work
- [x] No breaking changes - existing scripts continue to work

## Next Steps (After Merge)
1. Announce the change to users with clear migration guide
2. Update external documentation/websites if any
3. Consider deprecation notice for `threat-radar` in a future version (if desired)
4. Update any CI/CD pipelines to use `tr` for cleaner syntax

## Notes for @nymble (Paul)
Ready for your review and testing! 

The change is straightforward - we're just swapping which command is "primary" in the documentation while keeping both working. This makes the tool much more convenient to use day-to-day with the shorter `tr` command.

---

**Status**: ✅ Ready for Review  
**Backward Compatible**: ✅ Yes  
**Breaking Changes**: ❌ None
