### PR TITLE
Add --version flag to CLI

### DIFF
--- a/threat_radar/cli/app.py
+++ b/threat_radar/cli/app.py
@@ -3,6 +3,7 @@
 import typer
 from typing import Optional
 from pathlib import Path
+from importlib.metadata import version, PackageNotFoundError
 
 from . import (
     cve as cve_cmd,
@@ -17,6 +18,21 @@ from . import (
     health,
 )
 from ..utils.cli_context import CLIContext, set_cli_context
+
+
+def get_version() -> str:
+    """Get the current version of threat-radar."""
+    try:
+        return version("threat-radar")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def version_callback(value: bool) -> None:
+    """Print version and exit."""
+    if value:
+        typer.echo(f"threat-radar {get_version()}")
+        raise typer.Exit()
 
 app = typer.Typer(
     help="Threat Radar - Enterprise-grade threat assessment and vulnerability analysis",
@@ -44,6 +60,13 @@ app.add_typer(health.app, name="health", help="Health check and system status")
 
 @app.callback()
 def main_callback(
+    version_flag: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version and exit",
+    ),
     config_file: Optional[Path] = typer.Option(
         None,
         "--config",


### PR DESCRIPTION
## Summary
This PR implements Issue #122 by adding a `--version` flag to the Threat Radar CLI.

## Changes
- Added `--version` flag to the main CLI callback
- Implemented `get_version()` function using `importlib.metadata.version()`
- Version is read dynamically from package metadata (pyproject.toml)
- Display format: `threat-radar X.Y.Z`
- Version flag is marked as `is_eager=True` to allow usage without subcommands
- Gracefully falls back to 'unknown' if package not found

## Testing Instructions
After installing the package:

```bash
# Install in development mode
pip install -e .

# Test version flag
threat-radar --version
# Expected output: threat-radar 0.5.1

# Test with tradar alias
tradar --version
# Expected output: threat-radar 0.5.1

# Test help includes version option
threat-radar --help
```

## Notes
- Both `threat-radar` and `tradar` command aliases work with `--version`
- Version flag works independently, doesn't require a subcommand
- Version is sourced from pyproject.toml via package metadata

Fixes #122